### PR TITLE
Fix full codec generation

### DIFF
--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -203,11 +203,10 @@ class CodecCodeGen(codecParents: List[String],
         new File(s"${d.name}Formats.scala")
     }
 
-
-  private def getAllRequiredFormats(s: Document): List[String] =
-    s.definitions collect {
+  private def getAllFormatsForSchema(s: Document): List[String] =
+    getAllRequiredFormats(s, (s.definitions collect {
       case td: TypeDefinition => td
-    } flatMap { getAllRequiredFormats(s, _) }
+    }).toList)
 
   /**
    * Returns the list of fully qualified codec names that we (transitively) need to generate a codec for `ds`,
@@ -306,7 +305,7 @@ class CodecCodeGen(codecParents: List[String],
   }
 
   private def generateFullCodec(s: Document, name: String): ListMap[File, String] = {
-    val allFormats = getAllRequiredFormats(s).distinct
+    val allFormats = getAllFormatsForSchema(s).distinct
     val parents = allFormats.mkString("extends ", EOL + "  with ", "")
     val code =
       s"""${genPackage(s)}

--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -307,7 +307,7 @@ class CodecCodeGen(codecParents: List[String],
 
   private def generateFullCodec(s: Document, name: String): ListMap[File, String] = {
     val allFormats = getAllRequiredFormats(s).distinct
-    val parents = allFormats.mkString("extends ", " with ", "")
+    val parents = allFormats.mkString("extends ", EOL + "  with ", "")
     val code =
       s"""${genPackage(s)}
          |trait $name $parents

--- a/library/src/test/scala/JsonSchemaExample.scala
+++ b/library/src/test/scala/JsonSchemaExample.scala
@@ -1054,15 +1054,15 @@ implicit lazy val PriorityLevelFormat: JsonFormat[com.example.PriorityLevel] = n
 
 // DO NOT EDIT MANUALLY
 package generated
-trait CustomProtocol extends generated.GreetingHeaderFormats
+trait CustomProtocol extends java.util.DateFormats
   with sjsonnew.BasicJsonProtocol
+  with generated.PriorityLevelFormats
+  with generated.GreetingHeaderFormats
   with generated.SimpleGreetingFormats
   with generated.GreetingExtraImplFormats
   with generated.GreetingWithAttachmentsFormats
   with generated.GreetingsFormats
   with generated.GreetingExtraFormats
-  with java.util.DateFormats
-  with generated.PriorityLevelFormats
 object CustomProtocol extends CustomProtocol""".stripMargin
 
   val growableAddOneFieldExample = """{

--- a/library/src/test/scala/JsonSchemaExample.scala
+++ b/library/src/test/scala/JsonSchemaExample.scala
@@ -1054,7 +1054,15 @@ implicit lazy val PriorityLevelFormat: JsonFormat[com.example.PriorityLevel] = n
 
 // DO NOT EDIT MANUALLY
 package generated
-trait CustomProtocol extends generated.GreetingHeaderFormats with sjsonnew.BasicJsonProtocol with generated.SimpleGreetingFormats with generated.GreetingExtraImplFormats with generated.GreetingWithAttachmentsFormats with generated.GreetingsFormats with generated.GreetingExtraFormats with java.util.DateFormats with generated.PriorityLevelFormats
+trait CustomProtocol extends generated.GreetingHeaderFormats
+  with sjsonnew.BasicJsonProtocol
+  with generated.SimpleGreetingFormats
+  with generated.GreetingExtraImplFormats
+  with generated.GreetingWithAttachmentsFormats
+  with generated.GreetingsFormats
+  with generated.GreetingExtraFormats
+  with java.util.DateFormats
+  with generated.PriorityLevelFormats
 object CustomProtocol extends CustomProtocol""".stripMargin
 
   val growableAddOneFieldExample = """{


### PR DESCRIPTION
Fixes #61 

Here's how it's going to generate now.
Also added line breaks.

```scala
/**
 * This code is generated using sbt-datatype.
 */

// DO NOT EDIT MANUALLY
package sbt.librarymanagement
trait LibraryManagementCodec extends
  _root_.OptionFormats with
  sjsonnew.BasicJsonProtocol with
  sbt.librarymanagement.ConfigurationFormats with
  _root_.MapFormats with
  sbt.librarymanagement.ArtifactFormats with
  _root_.SetFormats with
  sbt.librarymanagement.ArtifactTypeFilterFormats with
  sbt.librarymanagement.InclExclRuleFormats with
  sbt.librarymanagement.DisabledFormats with
  sbt.librarymanagement.BinaryFormats with
  sbt.librarymanagement.FullFormats with
  sbt.librarymanagement.CrossVersionFormats with
  sbt.librarymanagement.ModuleIDFormats with
  sbt.librarymanagement.CallerFormats with
  scala.Tuple2Formats with
  sbt.librarymanagement.ModuleReportFormats with
  sbt.librarymanagement.OrganizationArtifactReportFormats with
  sbt.librarymanagement.ConfigurationReportFormats with
  sbt.librarymanagement.ConflictManagerFormats with
  sbt.librarymanagement.DeveloperFormats with
  sbt.librarymanagement.FileConfigurationFormats with
  scala.VectorFormats with
  sbt.librarymanagement.IvyScalaFormats with
  sbt.librarymanagement.ChainedResolverFormats with
  sbt.librarymanagement.MavenRepoFormats with
  sbt.librarymanagement.MavenCacheFormats with
  sbt.librarymanagement.PatternsFormats with
  sbt.librarymanagement.FileRepositoryFormats with
  sbt.librarymanagement.URLRepositoryFormats with
  sbt.librarymanagement.PasswordAuthenticationFormats with
  sbt.librarymanagement.KeyFileAuthenticationFormats with
  sbt.librarymanagement.SshAuthenticationFormats with
  sbt.librarymanagement.SshConnectionFormats with
  sbt.librarymanagement.SshRepositoryFormats with
  sbt.librarymanagement.SftpRepositoryFormats with
  sbt.librarymanagement.ResolverFormats with
  sbt.librarymanagement.ModuleConfigurationFormats with
  sbt.librarymanagement.ModuleInfoFormats with
  sbt.librarymanagement.IvyFileConfigurationFormats with
  sbt.librarymanagement.PomConfigurationFormats with
  sbt.librarymanagement.SbtExclusionRuleFormats with
  scala.xml.NodeSeqFormats with
  sbt.librarymanagement.InlineConfigurationFormats with
  sbt.librarymanagement.ModuleSettingsFormats with
  sbt.librarymanagement.MavenRepositoryFormats with
  sbt.librarymanagement.PatternsBasedRepositoryFormats with
  sbt.librarymanagement.SshBasedRepositoryFormats with
  sbt.librarymanagement.ScmInfoFormats with
  sbt.librarymanagement.RetrieveConfigurationFormats with
  sbt.librarymanagement.UpdateLoggingFormats with
  sbt.librarymanagement.UpdateConfigurationFormats with
  sbt.librarymanagement.UpdateStatsFormats with
  sbt.librarymanagement.UpdateReportFormats with
  sbt.librarymanagement.ConfigurationReportLiteFormats with
  xsbti.GlobalLockFormats with
  xsbti.LoggerFormats with
  sbt.librarymanagement.UpdateOptionsFormats with
  sbt.librarymanagement.IvyPathsFormats with
  sbt.librarymanagement.InlineIvyConfigurationFormats with
  sbt.librarymanagement.ExternalIvyConfigurationFormats with
  sbt.librarymanagement.IvyConfigurationFormats with
  sbt.librarymanagement.UpdateReportLiteFormats
object LibraryManagementCodec extends LibraryManagementCodec
```
