### PR TITLE
Implement generateCodec annotation that lets you skip it

### DIFF
--- a/docs/03-json.md
+++ b/docs/03-json.md
@@ -64,3 +64,15 @@ q: com.example.Person = Person(Bob, 20)
 
 scala> assert(p == q)
 ```
+
+### Skipping codec generation
+
+Use the `@generateCodec(false)` annotation to skip the codec generation for some types.
+
+```
+interface MiddleInterface implements InterfaceExample
+@generateCodec(false)
+{
+  field: Int
+}
+```

--- a/docs/ja/03-json.md
+++ b/docs/ja/03-json.md
@@ -64,3 +64,15 @@ q: com.example.Person = Person(Bob, 20)
 
 scala> assert(p == q)
 ```
+
+### コーデック生成のスキップ
+
+`@generateCodec(false)` アノテーションを使うことで特定の型をコーデック生成から除外することができる。
+
+```
+interface MiddleInterface implements InterfaceExample
+@generateCodec(false)
+{
+  field: Int
+}
+```

--- a/library/src/main/scala/sbt/contraband/CodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodeGen.scala
@@ -191,7 +191,7 @@ abstract class CodeGenerator {
   def generate(s: Document): ListMap[File, String]
 
   /** Generate the code corresponding to `d`. */
-  protected final def generate(s: Document, d: TypeDefinition): ListMap[File, String] =
+  protected def generate(s: Document, d: TypeDefinition): ListMap[File, String] =
     d match {
       case i: InterfaceTypeDefinition => generateInterface(s, i)
       case r: ObjectTypeDefinition    => generateRecord(s, r)

--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -183,7 +183,8 @@ class CodecCodeGen(codecParents: List[String],
     val codecs: ListMap[File, String] = ((s.definitions collect {
       case td: TypeDefinition => td
     } map { d =>
-      ListMap(generate(s, d).toSeq: _*) }) reduce (_ merge _)) mapV (_.indented)
+      ListMap(generate(s, d).toSeq: _*)
+    }) reduce (_ merge _)) mapV (_.indented)
     val result = toFullCodec(s) match {
       case Some(x) =>
         val full = generateFullCodec(s, x)
@@ -193,6 +194,10 @@ class CodecCodeGen(codecParents: List[String],
     }
     result map { case (k, v) => (k, generateHeader + v) }
   }
+
+  protected override def generate(s: Document, d: TypeDefinition): ListMap[File, String] =
+    if (!getGenerateCodec(d.directives)) ListMap.empty
+    else super.generate(s, d)
 
   private def genFile(s: Document, d: TypeDefinition): File =
     toCodecPackage(s) match {

--- a/library/src/test/scala/GraphQLCodecCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLCodecCodeGenSpec.scala
@@ -69,17 +69,7 @@ class GraphQLCodecCodeGenSpec extends FlatSpec with Matchers with Inside with Eq
         |trait InterfaceExampleFormats { self: sjsonnew.BasicJsonProtocol with generated.ChildTypeFormats =>
         |  implicit lazy val InterfaceExampleFormat: JsonFormat[com.example.InterfaceExample] = flatUnionFormat1[com.example.InterfaceExample, com.example.ChildType]("type")
         |}""".stripMargin.unindent)
-    code(new File("generated", "MiddleInterfaceFormats.scala")).unindent should equalLines (
-      """/**
-        | * This code is generated using sbt-datatype.
-        | */
-        |
-        |// DO NOT EDIT MANUALLY
-        |package generated
-        |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait MiddleInterfaceFormats { self: sjsonnew.BasicJsonProtocol with generated.ChildTypeFormats =>
-        |  implicit lazy val MiddleInterfaceFormat: JsonFormat[com.example.MiddleInterface] = flatUnionFormat1[com.example.MiddleInterface, com.example.ChildType]("type")
-        |}""".stripMargin.unindent)
+    code.contains(new File("generated", "MiddleInterfaceFormats.scala")) shouldEqual false
     code(new File("generated", "ChildTypeFormats.scala")).unindent should equalLines (
       """/**
         | * This code is generated using sbt-datatype.

--- a/library/src/test/scala/GraphQLExample.scala
+++ b/library/src/test/scala/GraphQLExample.scala
@@ -51,7 +51,9 @@ interface InterfaceExample {
   field: Int
 }
 
-interface MiddleInterface implements InterfaceExample {
+interface MiddleInterface implements InterfaceExample
+@generateCodec(false)
+{
   field: Int
 }
 

--- a/library/src/test/scala/JsonCodecCodeGenSpec.scala
+++ b/library/src/test/scala/JsonCodecCodeGenSpec.scala
@@ -139,17 +139,7 @@ class JsonCodecCodeGenSpec extends GCodeGenSpec("Codec") {
         |trait NestedProtocolExampleFormats { self: sjsonnew.BasicJsonProtocol with generated.ChildRecordFormats =>
         |  implicit lazy val nestedProtocolExampleFormat: JsonFormat[_root_.nestedProtocolExample] = flatUnionFormat1[_root_.nestedProtocolExample, _root_.ChildRecord]("type")
         |}""".stripMargin.unindent)
-    code(new File("generated", "nestedProtocolFormats.scala")).unindent should equalLines (
-      """/**
-        | * This code is generated using sbt-datatype.
-        | */
-        |
-        |// DO NOT EDIT MANUALLY
-        |package generated
-        |import _root_.sjsonnew.{ deserializationError, serializationError, Builder, JsonFormat, Unbuilder }
-        |trait NestedProtocolFormats { self: sjsonnew.BasicJsonProtocol with generated.ChildRecordFormats =>
-        |  implicit lazy val nestedProtocolFormat: JsonFormat[_root_.nestedProtocol] = flatUnionFormat1[_root_.nestedProtocol, _root_.ChildRecord]("type")
-        |}""".stripMargin.unindent)
+    code.contains(new File("generated", "nestedProtocolFormats.scala")) shouldEqual false
   }
 
   def interfaceGenerateMessages = {

--- a/library/src/test/scala/JsonSchemaExample.scala
+++ b/library/src/test/scala/JsonSchemaExample.scala
@@ -95,6 +95,7 @@ object JsonSchemaExample {
       "name": "nestedProtocol",
       "target": "Scala",
       "type": "interface",
+      "generateCodec": false,
       "types": [
         {
           "name": "ChildRecord",


### PR DESCRIPTION
This PR is on top of #62 and #63 
Fixes #55

Here's Contraband schema language:

```
interface MiddleInterface implements InterfaceExample
@generateCodec(false)
{
  field: Int
}
```

Here's the JSON notation:


```json
{
  "name": "MiddleInterface",
  "target": "Scala",
  "type": "interface",
  "generateCodec": false,
  "types": [ ]
}
```

