### PR TITLE
Add StringStringMap

### DIFF
--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -306,6 +306,7 @@ class CodecCodeGen(codecParents: List[String],
     case "long"    => "Long"
     case "short"   => "Short"
     case "double"  => "Double"
+    case "StringStringMap" => "scala.collection.immutable.Map[String, String]"
     case other     => other
   }
 
@@ -372,6 +373,7 @@ object CodecCodeGen {
       case "Boolean" | "Byte" | "Char" | "Float" | "Int" | "Long" | "Short" | "Double" => Nil
       case "java.util.UUID" | "java.net.URI" | "java.net.URL" | "java.util.Calendar" | "java.math.BigInteger"
         | "java.math.BigDecimal" | "java.io.File" => Nil
+      case "StringStringMap" => Nil
       case _ => forOthers(tpe)
     }
   }

--- a/library/src/main/scala/sbt/contraband/ScalaCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/ScalaCodeGen.scala
@@ -184,6 +184,7 @@ class ScalaCodeGen(javaLazy: String, javaOptional: String, instantiateJavaOption
     case "long"    => "Long"
     case "short"   => "Short"
     case "double"  => "Double"
+    case "StringStringMap" => "scala.collection.immutable.Map[String, String]"
     case other     => other
   }
 

--- a/library/src/test/scala/GraphQLExample.scala
+++ b/library/src/test/scala/GraphQLExample.scala
@@ -25,6 +25,14 @@ type TypeExample {
   #x // Some extra code
 }"""
 
+  val stringStringMapExample = """
+package com.example @target(Scala)
+
+## Example of a type
+type TypeExample {
+  field: StringStringMap!
+}"""
+
   val intfExample = """
 package com.example @target(Scala)
 @codecPackage("generated")

--- a/library/src/test/scala/GraphQLScalaCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLScalaCodeGenSpec.scala
@@ -60,6 +60,37 @@ class GraphQLScalaCodeGenSpec extends FlatSpec with Matchers with Inside with Eq
         |}""".stripMargin.unindent)
   }
 
+  it should "generate Map[String, String] from StringStringMap" in {
+    val Success(ast) = SchemaParser.parse(stringStringMapExample)
+    // println(ast)
+    val code = mkScalaCodeGen.generate(ast)
+    code.head._2.unindent should equalLines(
+      """package com.example
+        |/** Example of a type */
+        |final class TypeExample private (
+        |val field: scala.collection.immutable.Map[String, String]) extends Serializable {
+        |  override def equals(o: Any): Boolean = o match {
+        |    case x: TypeExample => (this.field == x.field)
+        |    case _ => false
+        |  }
+        |  override def hashCode: Int = {
+        |    37 * (17 + field.##)
+        |  }
+        |  override def toString: String = {
+        |    "TypeExample(" + field + ")"
+        |  }
+        |  protected[this] def copy(field: scala.collection.immutable.Map[String, String] = field): TypeExample = {
+        |    new TypeExample(field)
+        |  }
+        |  def withField(field: scala.collection.immutable.Map[String, String]): TypeExample = {
+        |    copy(field = field)
+        |  }
+        |}
+        |object TypeExample {
+        |  def apply(field: scala.collection.immutable.Map[String, String]): TypeExample = new TypeExample(field)
+        |}""".stripMargin.unindent)
+  }
+
   it should "grow a record from 0 to 1 field" in {
     val Success(ast) = SchemaParser.parse(growableAddOneFieldExample)
     // println(ast)

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/src/main/contraband/map.contra
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/src/main/contraband/map.contra
@@ -1,0 +1,9 @@
+package com.example
+@codecPackage("com.example.codec")
+@codecTypeField("$type")
+@fullCodec("MapJsonProtocol")
+@target(Scala)
+
+type Foo {
+  field: StringStringMap!
+}


### PR DESCRIPTION
I noticed we have `Map[String, String]` in https://github.com/sbt/sbt/blob/367ab3b2d34655345bdb9ccac83a97f7b0140090/run/src/main/scala/sbt/Fork.scala#L30