### PR TITLE
use static method make to create Java objects

### DIFF
--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -99,9 +99,10 @@ class CodecCodeGen(codecParents: List[String],
     val fqn = fullyQualifiedName(r)
     val allFields = r.fields // superFields ++ r.fields
     val getFields = allFields map (f => s"""val ${bq(f.name)} = unbuilder.readField[${genRealTpe(f.fieldType, intfLanguage)}]("${f.name}")""") mkString EOL
+    val factoryMethodName = "make"
     val reconstruct =
       if (targetLang == "Scala") s"$fqn(" + allFields.map(accessField).mkString(", ") + ")"
-      else s"new $fqn(" + allFields.map(accessField).mkString(", ") + ")"
+      else s"$fqn.$factoryMethodName(" + allFields.map(accessField).mkString(", ") + ")"
     val writeFields = allFields map (f => s"""builder.addField("${f.name}", obj.${bq(f.name)})""") mkString EOL
     val selfType = makeSelfType(s, r)
 

--- a/library/src/test/scala/GraphQLJavaCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLJavaCodeGenSpec.scala
@@ -32,12 +32,18 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |public final class TypeExample implements java.io.Serializable {
         |    // Some extra code
         |
+        |    public static TypeExample make(java.util.Optional<java.net.URL> _field) {
+        |        return new TypeExample(_field);
+        |    }
+        |    public static TypeExample make(java.net.URL _field) {
+        |        return new TypeExample(_field);
+        |    }
         |    private java.util.Optional<java.net.URL> field;
-        |    public TypeExample(java.util.Optional<java.net.URL> _field) {
+        |    protected TypeExample(java.util.Optional<java.net.URL> _field) {
         |        super();
         |        field = _field;
         |    }
-        |    public TypeExample(java.net.URL _field) {
+        |    protected TypeExample(java.net.URL _field) {
         |        super();
         |        field = java.util.Optional.<java.net.URL>ofNullable(_field);
         |    }
@@ -77,16 +83,25 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
     code.head._2.unindent should equalLines (
       """package com.example;
         |public final class Growable implements java.io.Serializable {
+        |    public static Growable make() {
+        |        return new Growable();
+        |    }
+        |    public static Growable make(java.util.Optional<Integer> _field) {
+        |        return new Growable(_field);
+        |    }
+        |    public static Growable make(int _field) {
+        |        return new Growable(_field);
+        |    }
         |    private java.util.Optional<Integer> field;
-        |    public Growable() {
+        |    protected Growable() {
         |        super();
         |        field = java.util.Optional.<Integer>ofNullable(0);
         |    }
-        |    public Growable(java.util.Optional<Integer> _field) {
+        |    protected Growable(java.util.Optional<Integer> _field) {
         |        super();
         |        field = _field;
         |    }
-        |    public Growable(int _field) {
+        |    protected Growable(int _field) {
         |        super();
         |        field = java.util.Optional.<Integer>ofNullable(_field);
         |    }
@@ -126,29 +141,44 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
     code.head._2.unindent should equalLines (
       """package com.example;
         |public final class Foo implements java.io.Serializable {
+        |    public static Foo make() {
+        |        return new Foo();
+        |    }
+        |    public static Foo make(java.util.Optional<Integer> _x) {
+        |        return new Foo(_x);
+        |    }
+        |    public static Foo make(int _x) {
+        |        return new Foo(_x);
+        |    }
+        |    public static Foo make(java.util.Optional<Integer> _x, int[] _y) {
+        |        return new Foo(_x, _y);
+        |    }
+        |    public static Foo make(int _x, int[] _y) {
+        |        return new Foo(_x, _y);
+        |    }
         |    private java.util.Optional<Integer> x;
         |    private int[] y;
-        |    public Foo() {
+        |    protected Foo() {
         |        super();
         |        x = java.util.Optional.<Integer>empty();
         |        y = new Array {};
         |    }
-        |    public Foo(java.util.Optional<Integer> _x) {
+        |    protected Foo(java.util.Optional<Integer> _x) {
         |        super();
         |        x = _x;
         |        y = new Array {};
         |    }
-        |    public Foo(int _x) {
+        |    protected Foo(int _x) {
         |        super();
         |        x = java.util.Optional.<Integer>ofNullable(_x);
         |        y = new Array {};
         |    }
-        |    public Foo(java.util.Optional<Integer> _x, int[] _y) {
+        |    protected Foo(java.util.Optional<Integer> _x, int[] _y) {
         |        super();
         |        x = _x;
         |        y = _y;
         |    }
-        |    public Foo(int _x, int[] _y) {
+        |    protected Foo(int _x, int[] _y) {
         |        super();
         |        x = java.util.Optional.<Integer>ofNullable(_x);
         |        y = _y;
@@ -200,11 +230,11 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |
         |    // Some extra code
         |    private java.util.Optional<Integer> field;
-        |    public InterfaceExample(java.util.Optional<Integer> _field) {
+        |    protected InterfaceExample(java.util.Optional<Integer> _field) {
         |        super();
         |        field = _field;
         |    }
-        |    public InterfaceExample(int _field) {
+        |    protected InterfaceExample(int _field) {
         |        super();
         |        field = java.util.Optional.<Integer>ofNullable(_field);
         |    }
@@ -231,12 +261,18 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
     code2 should equalLines (
       """package com.example;
         |public final class ChildType extends com.example.InterfaceExample {
+        |    public static ChildType make(java.util.Optional<String> _name, java.util.Optional<Integer> _field) {
+        |        return new ChildType(_name, _field);
+        |    }
+        |    public static ChildType make(String _name, int _field) {
+        |        return new ChildType(_name, _field);
+        |    }
         |    private java.util.Optional<String> name;
-        |    public ChildType(java.util.Optional<String> _name, java.util.Optional<Integer> _field) {
+        |    protected ChildType(java.util.Optional<String> _name, java.util.Optional<Integer> _field) {
         |        super(_field);
         |         name = _name;
         |    }
-        |    public ChildType(String _name, int _field) {
+        |    protected ChildType(String _name, int _field) {
         |        super(java.util.Optional.<Integer>ofNullable(_field));
         |         name = java.util.Optional.<String>ofNullable(_name);
         |    }
@@ -282,11 +318,11 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |public abstract class IntfExample implements java.io.Serializable {
         |    /** I'm a field. */
         |    private java.util.Optional<Integer> field;
-        |    public IntfExample(java.util.Optional<Integer> _field) {
+        |    protected IntfExample(java.util.Optional<Integer> _field) {
         |        super();
         |        field = _field;
         |    }
-        |    public IntfExample(int _field) {
+        |    protected IntfExample(int _field) {
         |        super();
         |        field = java.util.Optional.<Integer>ofNullable(_field);
         |    }

--- a/library/src/test/scala/GraphQLMixedCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLMixedCodeGenSpec.scala
@@ -30,17 +30,17 @@ public abstract class Greeting implements java.io.Serializable {
 
     private String message;
     private java.util.Optional<String> s;
-    public Greeting(String _message) {
+    protected Greeting(String _message) {
         super();
         message = _message;
         s = java.util.Optional.<String>ofNullable("1");
     }
-    public Greeting(String _message, java.util.Optional<String> _s) {
+    protected Greeting(String _message, java.util.Optional<String> _s) {
         super();
         message = _message;
         s = _s;
     }
-    public Greeting(String _message, String _s) {
+    protected Greeting(String _message, String _s) {
         super();
         message = _message;
         s = java.util.Optional.<String>ofNullable(_s);

--- a/library/src/test/scala/JsonJavaCodeGenSpec.scala
+++ b/library/src/test/scala/JsonJavaCodeGenSpec.scala
@@ -31,7 +31,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         |public abstract class simpleInterfaceExample implements java.io.Serializable {
         |    // Some extra code...
         |    private type field;
-        |    public simpleInterfaceExample(type _field) {
+        |    protected simpleInterfaceExample(type _field) {
         |        super();
         |        field = _field;
         |    }
@@ -67,7 +67,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         |public abstract class oneChildInterfaceExample implements java.io.Serializable {
         |
         |    private int field;
-        |    public oneChildInterfaceExample(int _field) {
+        |    protected oneChildInterfaceExample(int _field) {
         |        super();
         |        field = _field;
         |    }
@@ -93,8 +93,11 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         |}""".stripMargin.unindent)
     code2 should equalLines (
       """public final class childRecord extends oneChildInterfaceExample {
+        |    public static childRecord make(int _field, int _x) {
+        |        return new childRecord(_field, _x);
+        |    }
         |    private int x;
-        |    public childRecord(int _field, int _x) {
+        |    protected childRecord(int _field, int _x) {
         |        super(_field);
         |         x = _x;
         |    }
@@ -135,7 +138,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         new File("nestedProtocolExample.java") ->
           """/** example of nested protocols */
             |public abstract class nestedProtocolExample implements java.io.Serializable {
-            |    public nestedProtocolExample() {
+            |    protected nestedProtocolExample() {
             |        super();
             |    }
             |    public boolean equals(Object obj) {
@@ -158,7 +161,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
 
         new File("nestedProtocol.java") ->
           """public abstract class nestedProtocol extends nestedProtocolExample {
-            |    public nestedProtocol() {
+            |    protected nestedProtocol() {
             |        super();
             |    }
             |    public boolean equals(Object obj) {
@@ -181,7 +184,10 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
 
         new File("ChildRecord.java") ->
           """public final class ChildRecord extends nestedProtocol {
-            |    public ChildRecord() {
+            |    public static ChildRecord make() {
+            |        return new ChildRecord();
+            |    }
+            |    protected ChildRecord() {
             |        super();
             |    }
             |    public boolean equals(Object obj) {
@@ -214,7 +220,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
           """public abstract class generateArgDocExample implements java.io.Serializable {
             |    /** I'm a field. */
             |    private int field;
-            |    public generateArgDocExample(int _field) {
+            |    protected generateArgDocExample(int _field) {
             |        super();
             |        field = _field;
             |    }
@@ -260,8 +266,11 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             |public final class simpleRecordExample implements java.io.Serializable {
             |    // Some extra code...
             |
+            |    public static simpleRecordExample make(java.net.URL _field) {
+            |        return new simpleRecordExample(_field);
+            |    }
             |    private java.net.URL field;
-            |    public simpleRecordExample(java.net.URL _field) {
+            |    protected simpleRecordExample(java.net.URL _field) {
             |        super();
             |        field = _field;
             |    }
@@ -299,12 +308,18 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
       ListMap(
         new File("growableAddOneField.java") ->
           """public final class growableAddOneField implements java.io.Serializable {
+            |    public static growableAddOneField make() {
+            |        return new growableAddOneField();
+            |    }
+            |    public static growableAddOneField make(int _field) {
+            |        return new growableAddOneField(_field);
+            |    }
             |    private int field;
-            |    public growableAddOneField() {
+            |    protected growableAddOneField() {
             |        super();
             |        field = 0;
             |    }
-            |    public growableAddOneField(int _field) {
+            |    protected growableAddOneField(int _field) {
             |        super();
             |        field = _field;
             |    }
@@ -342,29 +357,44 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
       ListMap(
         new File("Foo.java") ->
           """public final class Foo implements java.io.Serializable {
+            |    public static Foo make() {
+            |        return new Foo();
+            |    }
+            |    public static Foo make(java.util.Optional<Integer> _x) {
+            |        return new Foo(_x);
+            |    }
+            |    public static Foo make(int _x) {
+            |        return new Foo(_x);
+            |    }
+            |    public static Foo make(java.util.Optional<Integer> _x, int[] _y) {
+            |        return new Foo(_x, _y);
+            |    }
+            |    public static Foo make(int _x, int[] _y) {
+            |        return new Foo(_x, _y);
+            |    }
             |    private java.util.Optional<Integer> x;
             |    private int[] y;
-            |    public Foo() {
+            |    protected Foo() {
             |        super();
             |        x = java.util.Optional.<String>ofNullable(0);
             |        y = new Array { 0 };
             |    }
-            |    public Foo(java.util.Optional<Integer> _x) {
+            |    protected Foo(java.util.Optional<Integer> _x) {
             |        super();
             |        x = _x;
             |        y = new Array { 0 };
             |    }
-            |    public Foo(int _x) {
+            |    protected Foo(int _x) {
             |        super();
             |        x = java.util.Optional.<Integer>ofNullable(_x);
             |        y = new Array { 0 };
             |    }
-            |    public Foo(java.util.Optional<Integer> _x, int[] _y) {
+            |    protected Foo(java.util.Optional<Integer> _x, int[] _y) {
             |      super();
             |      x = _x;
             |      y = _y;
             |    }
-            |    public Foo(int _x, int[] _y) {
+            |    protected Foo(int _x, int[] _y) {
             |        super();
             |        x = java.util.Optional.<Integer>ofNullable(_x);
             |        y = _y;
@@ -414,9 +444,12 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
           """public final class primitiveTypesExample2 implements java.io.Serializable {
 
 
+    public static primitiveTypesExample2 make(boolean _smallBoolean, boolean _bigBoolean) {
+        return new primitiveTypesExample2(_smallBoolean, _bigBoolean);
+    }
     private boolean smallBoolean;
     private boolean bigBoolean;
-    public primitiveTypesExample2(boolean _smallBoolean, boolean _bigBoolean) {
+    protected primitiveTypesExample2(boolean _smallBoolean, boolean _bigBoolean) {
         super();
         smallBoolean = _smallBoolean;
         bigBoolean = _bigBoolean;
@@ -460,13 +493,19 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
     code.head._2.unindent should equalLines (
       """public final class primitiveTypesExample implements java.io.Serializable {
         |
+        |    public static primitiveTypesExample make(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, java.util.Optional<Integer> _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
+        |        return new primitiveTypesExample(_simpleInteger, _lazyInteger, _arrayInteger, _optionInteger, _lazyArrayInteger, _lazyOptionInteger);
+        |    }
+        |    public static primitiveTypesExample make(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, int _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
+        |        return new primitiveTypesExample(_simpleInteger, _lazyInteger, _arrayInteger, _optionInteger, _lazyArrayInteger, _lazyOptionInteger);
+        |    }
         |    private int simpleInteger;
         |    private com.example.MyLazy<Integer> lazyInteger;
         |    private int[] arrayInteger;
         |    private java.util.Optional<Integer> optionInteger;
         |    private com.example.MyLazy<int[]> lazyArrayInteger;
         |    private com.example.MyLazy<java.util.Optional<Integer>> lazyOptionInteger;
-        |    public primitiveTypesExample(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, java.util.Optional<Integer> _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
+        |    protected primitiveTypesExample(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, java.util.Optional<Integer> _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
         |        super();
         |        simpleInteger = _simpleInteger;
         |        lazyInteger = _lazyInteger;
@@ -475,7 +514,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         |        lazyArrayInteger = _lazyArrayInteger;
         |        lazyOptionInteger = _lazyOptionInteger;
         |    }
-        |    public primitiveTypesExample(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, int _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
+        |    protected primitiveTypesExample(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, int _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
         |        super();
         |        simpleInteger = _simpleInteger;
         |        lazyInteger = _lazyInteger;
@@ -547,10 +586,13 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         new File("primitiveTypesNoLazyExample.java") ->
           """public final class primitiveTypesNoLazyExample implements java.io.Serializable {
             |
+            |    public static primitiveTypesNoLazyExample make(int _simpleInteger, int[] _arrayInteger) {
+            |        return new primitiveTypesNoLazyExample(_simpleInteger, _arrayInteger);
+            |    }
             |    private int simpleInteger;
             |
             |    private int[] arrayInteger;
-            |    public primitiveTypesNoLazyExample(int _simpleInteger, int[] _arrayInteger) {
+            |    protected primitiveTypesNoLazyExample(int _simpleInteger, int[] _arrayInteger) {
             |        super();
             |        simpleInteger = _simpleInteger;
             |        arrayInteger = _arrayInteger;

--- a/library/src/test/scala/JsonSchemaExample.scala
+++ b/library/src/test/scala/JsonSchemaExample.scala
@@ -625,6 +625,12 @@ object PriorityLevel {
           |/** Meta information of a Greeting */
           |public final class GreetingHeader implements java.io.Serializable {
           |
+          |    public static GreetingHeader make(com.example.MyLazy<java.util.Date> _created, String _author) {
+          |        return new GreetingHeader(_created, _author);
+          |    }
+          |    public static GreetingHeader make(com.example.MyLazy<java.util.Date> _created, com.example.PriorityLevel _priority, String _author) {
+          |        return new GreetingHeader(_created, _priority, _author);
+          |    }
           |    /** Creation date */
           |    private com.example.MyLazy<java.util.Date> created;
           |    /** The priority of this Greeting */
@@ -632,14 +638,14 @@ object PriorityLevel {
           |    /** The author of the Greeting */
           |    private String author;
           |
-          |    public GreetingHeader(com.example.MyLazy<java.util.Date> _created, String _author) {
+          |    protected GreetingHeader(com.example.MyLazy<java.util.Date> _created, String _author) {
           |        super();
           |        created = _created;
           |        priority = com.example.PriorityLevel.Medium;
           |        author = _author;
           |    }
           |
-          |    public GreetingHeader(com.example.MyLazy<java.util.Date> _created, com.example.PriorityLevel _priority, String _author) {
+          |    protected GreetingHeader(com.example.MyLazy<java.util.Date> _created, com.example.PriorityLevel _priority, String _author) {
           |        super();
           |        created = _created;
           |        priority = _priority;
@@ -697,13 +703,19 @@ object PriorityLevel {
         """package com.example;
           |/** A Greeting with attachments */
           |public final class GreetingWithAttachments extends com.example.Greetings {
+          |    public static GreetingWithAttachments make(com.example.MyLazy<String> _message, java.io.File[] _attachments) {
+          |        return new GreetingWithAttachments(_message, _attachments);
+          |    }
+          |    public static GreetingWithAttachments make(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, java.io.File[] _attachments) {
+          |        return new GreetingWithAttachments(_message, _header, _attachments);
+          |    }
           |    /** The files attached to the greeting */
           |    private java.io.File[] attachments;
-          |    public GreetingWithAttachments(com.example.MyLazy<String> _message, java.io.File[] _attachments) {
+          |    protected GreetingWithAttachments(com.example.MyLazy<String> _message, java.io.File[] _attachments) {
           |        super(_message, new com.example.GreetingHeader(new java.util.Date(), "Unknown"));
           |        attachments = _attachments;
           |    }
-          |    public GreetingWithAttachments(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, java.io.File[] _attachments) {
+          |    protected GreetingWithAttachments(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, java.io.File[] _attachments) {
           |        super(_message, _header);
           |        attachments = _attachments;
           |    }
@@ -735,11 +747,11 @@ object PriorityLevel {
 public abstract class GreetingExtra extends com.example.Greetings {
 
     private String[] extra;
-    public GreetingExtra(com.example.MyLazy<String> _message, String[] _extra) {
+    protected GreetingExtra(com.example.MyLazy<String> _message, String[] _extra) {
         super(_message, new com.example.GreetingHeader(new java.util.Date(), "Unknown"));
         extra = _extra;
     }
-    public GreetingExtra(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, String[] _extra) {
+    protected GreetingExtra(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, String[] _extra) {
         super(_message, _header);
         extra = _extra;
     }
@@ -762,12 +774,18 @@ public abstract class GreetingExtra extends com.example.Greetings {
         """package com.example;
 public final class GreetingExtraImpl extends com.example.GreetingExtra {
 
+    public static GreetingExtraImpl make(com.example.MyLazy<String> _message, String[] _extra, String _x) {
+        return new GreetingExtraImpl(_message, _extra, _x);
+    }
+    public static GreetingExtraImpl make(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, String[] _extra, String _x) {
+        return new GreetingExtraImpl(_message, _header, _extra, _x);
+    }
     private String x;
-    public GreetingExtraImpl(com.example.MyLazy<String> _message, String[] _extra, String _x) {
+    protected GreetingExtraImpl(com.example.MyLazy<String> _message, String[] _extra, String _x) {
         super(_message, new com.example.GreetingHeader(new java.util.Date(), "Unknown"), _extra);
         x = _x;
     }
-    public GreetingExtraImpl(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, String[] _extra, String _x) {
+    protected GreetingExtraImpl(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, String[] _extra, String _x) {
         super(_message, _header, _extra);
         x = _x;
     }
@@ -810,13 +828,13 @@ public final class GreetingExtraImpl extends com.example.GreetingExtra {
           |    /** The header of the Greeting */
           |    private com.example.GreetingHeader header;
           |
-          |    public Greetings(com.example.MyLazy<String> _message) {
+          |    protected Greetings(com.example.MyLazy<String> _message) {
           |        super();
           |        message = _message;
           |        header = new com.example.GreetingHeader(new java.util.Date(), "Unknown");
           |    }
           |
-          |    public Greetings(com.example.MyLazy<String> _message, com.example.GreetingHeader _header) {
+          |    protected Greetings(com.example.MyLazy<String> _message, com.example.GreetingHeader _header) {
           |        super();
           |        message = _message;
           |        header = _header;
@@ -847,12 +865,17 @@ public final class GreetingExtraImpl extends com.example.GreetingExtra {
         """package com.example;
           |/** A Greeting in its simplest form */
           |public final class SimpleGreeting extends com.example.Greetings {
-          |
-          |    public SimpleGreeting(com.example.MyLazy<String> _message) {
+          |    public static SimpleGreeting make(com.example.MyLazy<String> _message) {
+          |        return new SimpleGreeting(_message);
+          |    }
+          |    public static SimpleGreeting make(com.example.MyLazy<String> _message, com.example.GreetingHeader _header) {
+          |        return new SimpleGreeting(_message, _header);
+          |    }
+          |    protected SimpleGreeting(com.example.MyLazy<String> _message) {
           |        super(_message, new com.example.GreetingHeader(new java.util.Date(), "Unknown"));
           |    }
           |
-          |    public SimpleGreeting(com.example.MyLazy<String> _message, com.example.GreetingHeader _header) {
+          |    protected SimpleGreeting(com.example.MyLazy<String> _message, com.example.GreetingHeader _header) {
           |        super(_message, _header);
           |    }
           |
@@ -953,7 +976,7 @@ implicit lazy val GreetingExtraImplFormat: JsonFormat[com.example.GreetingExtraI
       val extra = unbuilder.readField[Array[String]]("extra")
       val x = unbuilder.readField[String]("x")
       unbuilder.endObject()
-      new com.example.GreetingExtraImpl(mkLazy(message), header, extra, x)
+      com.example.GreetingExtraImpl.make(mkLazy(message), header, extra, x)
       case None =>
       deserializationError("Expected JsObject but found None")
     }

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/src/main/scala/com/foo/Example.scala
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/src/main/scala/com/foo/Example.scala
@@ -7,10 +7,10 @@ import com.example._
 
 object Example extends App {
   import generated.CustomProtocol._
-  val g0: Greeting = new SimpleGreeting("Hello")
-  val g1: Greeting = new SimpleGreeting("Hello", Optional.empty[Integer]())
-  val g21: Greeting = new GreetingWithAttachments("Hello", Array.empty)
-  val g3: Greeting = new GreetingWithOption("Hello", Optional.ofNullable("foo"))
+  val g0: Greeting = SimpleGreeting.make("Hello")
+  val g1: Greeting = SimpleGreeting.make("Hello", Optional.empty[Integer]())
+  val g21: Greeting = GreetingWithAttachments.make("Hello", Array.empty)
+  val g3: Greeting = GreetingWithOption.make("Hello", Optional.ofNullable("foo"))
 
   println(CompactPrinter(Converter.toJson(g0).get))
   println(Converter.fromJson[Greeting](Converter.toJson(g0).get).get)

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/src/main/scala/com/foo/Example.scala
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/src/main/scala/com/foo/Example.scala
@@ -9,7 +9,7 @@ object Example extends App {
   import generated.CustomProtocol._
   val g0: Greeting = SimpleGreeting("Hello")
   val g1: Greeting = SimpleGreeting("Hello", Optional.empty[java.lang.Integer]())
-  val g21: Greeting = new GreetingWithAttachments("Hello", Array.empty)
+  val g21: Greeting = GreetingWithAttachments.make("Hello", Array.empty)
   val g3: Greeting = GreetingWithOption("Hello", Optional.ofNullable("foo"))
 
   println(CompactPrinter(Converter.toJson(g0).get))


### PR DESCRIPTION
Fixes https://github.com/sbt/zinc/issues/317

Java code will now generate static factory methods named "make":

```java
public final class TypeExample implements java.io.Serializable {
    // Some extra code

    public static TypeExample make(java.util.Optional<java.net.URL> _field) {
        return new TypeExample(_field);
    }
    public static TypeExample make(java.net.URL _field) {
        return new TypeExample(_field);
    }
...
```
and the constructors are protected.

/cc @stuhood, @jvican  
