### PR TITLE
Change Java factory method name from make to create/of

### DIFF
--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -99,7 +99,7 @@ class CodecCodeGen(codecParents: List[String],
     val fqn = fullyQualifiedName(r)
     val allFields = r.fields // superFields ++ r.fields
     val getFields = allFields map (f => s"""val ${bq(f.name)} = unbuilder.readField[${genRealTpe(f.fieldType, intfLanguage)}]("${f.name}")""") mkString EOL
-    val factoryMethodName = "make"
+    val factoryMethodName = "of"
     val reconstruct =
       if (targetLang == "Scala") s"$fqn(" + allFields.map(accessField).mkString(", ") + ")"
       else s"$fqn.$factoryMethodName(" + allFields.map(accessField).mkString(", ") + ")"

--- a/library/src/test/scala/GraphQLJavaCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLJavaCodeGenSpec.scala
@@ -32,10 +32,16 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |public final class TypeExample implements java.io.Serializable {
         |    // Some extra code
         |
-        |    public static TypeExample make(java.util.Optional<java.net.URL> _field) {
+        |    public static TypeExample create(java.util.Optional<java.net.URL> _field) {
         |        return new TypeExample(_field);
         |    }
-        |    public static TypeExample make(java.net.URL _field) {
+        |    public static TypeExample of(java.util.Optional<java.net.URL> _field) {
+        |        return new TypeExample(_field);
+        |    }
+        |    public static TypeExample create(java.net.URL _field) {
+        |        return new TypeExample(_field);
+        |    }
+        |    public static TypeExample of(java.net.URL _field) {
         |        return new TypeExample(_field);
         |    }
         |    private java.util.Optional<java.net.URL> field;
@@ -83,13 +89,22 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
     code.head._2.unindent should equalLines (
       """package com.example;
         |public final class Growable implements java.io.Serializable {
-        |    public static Growable make() {
+        |    public static Growable create() {
         |        return new Growable();
         |    }
-        |    public static Growable make(java.util.Optional<Integer> _field) {
+        |    public static Growable of() {
+        |        return new Growable();
+        |    }
+        |    public static Growable create(java.util.Optional<Integer> _field) {
         |        return new Growable(_field);
         |    }
-        |    public static Growable make(int _field) {
+        |    public static Growable of(java.util.Optional<Integer> _field) {
+        |        return new Growable(_field);
+        |    }
+        |    public static Growable create(int _field) {
+        |        return new Growable(_field);
+        |    }
+        |    public static Growable of(int _field) {
         |        return new Growable(_field);
         |    }
         |    private java.util.Optional<Integer> field;
@@ -141,19 +156,34 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
     code.head._2.unindent should equalLines (
       """package com.example;
         |public final class Foo implements java.io.Serializable {
-        |    public static Foo make() {
+        |    public static Foo create() {
         |        return new Foo();
         |    }
-        |    public static Foo make(java.util.Optional<Integer> _x) {
+        |    public static Foo of() {
+        |        return new Foo();
+        |    }
+        |    public static Foo create(java.util.Optional<Integer> _x) {
         |        return new Foo(_x);
         |    }
-        |    public static Foo make(int _x) {
+        |    public static Foo of(java.util.Optional<Integer> _x) {
         |        return new Foo(_x);
         |    }
-        |    public static Foo make(java.util.Optional<Integer> _x, int[] _y) {
+        |    public static Foo create(int _x) {
+        |        return new Foo(_x);
+        |    }
+        |    public static Foo of(int _x) {
+        |        return new Foo(_x);
+        |    }
+        |    public static Foo create(java.util.Optional<Integer> _x, int[] _y) {
         |        return new Foo(_x, _y);
         |    }
-        |    public static Foo make(int _x, int[] _y) {
+        |    public static Foo of(java.util.Optional<Integer> _x, int[] _y) {
+        |        return new Foo(_x, _y);
+        |    }
+        |    public static Foo create(int _x, int[] _y) {
+        |        return new Foo(_x, _y);
+        |    }
+        |    public static Foo of(int _x, int[] _y) {
         |        return new Foo(_x, _y);
         |    }
         |    private java.util.Optional<Integer> x;
@@ -261,10 +291,16 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
     code2 should equalLines (
       """package com.example;
         |public final class ChildType extends com.example.InterfaceExample {
-        |    public static ChildType make(java.util.Optional<String> _name, java.util.Optional<Integer> _field) {
+        |    public static ChildType create(java.util.Optional<String> _name, java.util.Optional<Integer> _field) {
         |        return new ChildType(_name, _field);
         |    }
-        |    public static ChildType make(String _name, int _field) {
+        |    public static ChildType of(java.util.Optional<String> _name, java.util.Optional<Integer> _field) {
+        |        return new ChildType(_name, _field);
+        |    }
+        |    public static ChildType create(String _name, int _field) {
+        |        return new ChildType(_name, _field);
+        |    }
+        |    public static ChildType of(String _name, int _field) {
         |        return new ChildType(_name, _field);
         |    }
         |    private java.util.Optional<String> name;

--- a/library/src/test/scala/JsonJavaCodeGenSpec.scala
+++ b/library/src/test/scala/JsonJavaCodeGenSpec.scala
@@ -93,7 +93,10 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         |}""".stripMargin.unindent)
     code2 should equalLines (
       """public final class childRecord extends oneChildInterfaceExample {
-        |    public static childRecord make(int _field, int _x) {
+        |    public static childRecord create(int _field, int _x) {
+        |        return new childRecord(_field, _x);
+        |    }
+        |    public static childRecord of(int _field, int _x) {
         |        return new childRecord(_field, _x);
         |    }
         |    private int x;
@@ -184,7 +187,10 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
 
         new File("ChildRecord.java") ->
           """public final class ChildRecord extends nestedProtocol {
-            |    public static ChildRecord make() {
+            |    public static ChildRecord create() {
+            |        return new ChildRecord();
+            |    }
+            |    public static ChildRecord of() {
             |        return new ChildRecord();
             |    }
             |    protected ChildRecord() {
@@ -266,7 +272,10 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             |public final class simpleRecordExample implements java.io.Serializable {
             |    // Some extra code...
             |
-            |    public static simpleRecordExample make(java.net.URL _field) {
+            |    public static simpleRecordExample create(java.net.URL _field) {
+            |        return new simpleRecordExample(_field);
+            |    }
+            |    public static simpleRecordExample of(java.net.URL _field) {
             |        return new simpleRecordExample(_field);
             |    }
             |    private java.net.URL field;
@@ -308,10 +317,16 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
       ListMap(
         new File("growableAddOneField.java") ->
           """public final class growableAddOneField implements java.io.Serializable {
-            |    public static growableAddOneField make() {
+            |    public static growableAddOneField create() {
             |        return new growableAddOneField();
             |    }
-            |    public static growableAddOneField make(int _field) {
+            |    public static growableAddOneField of() {
+            |        return new growableAddOneField();
+            |    }
+            |    public static growableAddOneField create(int _field) {
+            |        return new growableAddOneField(_field);
+            |    }
+            |    public static growableAddOneField of(int _field) {
             |        return new growableAddOneField(_field);
             |    }
             |    private int field;
@@ -357,19 +372,34 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
       ListMap(
         new File("Foo.java") ->
           """public final class Foo implements java.io.Serializable {
-            |    public static Foo make() {
+            |    public static Foo create() {
             |        return new Foo();
             |    }
-            |    public static Foo make(java.util.Optional<Integer> _x) {
+            |    public static Foo of() {
+            |        return new Foo();
+            |    }
+            |    public static Foo create(java.util.Optional<Integer> _x) {
             |        return new Foo(_x);
             |    }
-            |    public static Foo make(int _x) {
+            |    public static Foo of(java.util.Optional<Integer> _x) {
             |        return new Foo(_x);
             |    }
-            |    public static Foo make(java.util.Optional<Integer> _x, int[] _y) {
+            |    public static Foo create(int _x) {
+            |        return new Foo(_x);
+            |    }
+            |    public static Foo of(int _x) {
+            |        return new Foo(_x);
+            |    }
+            |    public static Foo create(java.util.Optional<Integer> _x, int[] _y) {
             |        return new Foo(_x, _y);
             |    }
-            |    public static Foo make(int _x, int[] _y) {
+            |    public static Foo of(java.util.Optional<Integer> _x, int[] _y) {
+            |        return new Foo(_x, _y);
+            |    }
+            |    public static Foo create(int _x, int[] _y) {
+            |        return new Foo(_x, _y);
+            |    }
+            |    public static Foo of(int _x, int[] _y) {
             |        return new Foo(_x, _y);
             |    }
             |    private java.util.Optional<Integer> x;
@@ -444,7 +474,10 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
           """public final class primitiveTypesExample2 implements java.io.Serializable {
 
 
-    public static primitiveTypesExample2 make(boolean _smallBoolean, boolean _bigBoolean) {
+    public static primitiveTypesExample2 create(boolean _smallBoolean, boolean _bigBoolean) {
+        return new primitiveTypesExample2(_smallBoolean, _bigBoolean);
+    }
+    public static primitiveTypesExample2 of(boolean _smallBoolean, boolean _bigBoolean) {
         return new primitiveTypesExample2(_smallBoolean, _bigBoolean);
     }
     private boolean smallBoolean;
@@ -493,10 +526,16 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
     code.head._2.unindent should equalLines (
       """public final class primitiveTypesExample implements java.io.Serializable {
         |
-        |    public static primitiveTypesExample make(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, java.util.Optional<Integer> _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
+        |    public static primitiveTypesExample create(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, java.util.Optional<Integer> _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
         |        return new primitiveTypesExample(_simpleInteger, _lazyInteger, _arrayInteger, _optionInteger, _lazyArrayInteger, _lazyOptionInteger);
         |    }
-        |    public static primitiveTypesExample make(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, int _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
+        |    public static primitiveTypesExample of(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, java.util.Optional<Integer> _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
+        |        return new primitiveTypesExample(_simpleInteger, _lazyInteger, _arrayInteger, _optionInteger, _lazyArrayInteger, _lazyOptionInteger);
+        |    }
+        |    public static primitiveTypesExample create(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, int _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
+        |        return new primitiveTypesExample(_simpleInteger, _lazyInteger, _arrayInteger, _optionInteger, _lazyArrayInteger, _lazyOptionInteger);
+        |    }
+        |    public static primitiveTypesExample of(int _simpleInteger, com.example.MyLazy<Integer> _lazyInteger, int[] _arrayInteger, int _optionInteger, com.example.MyLazy<int[]> _lazyArrayInteger, com.example.MyLazy<java.util.Optional<Integer>> _lazyOptionInteger) {
         |        return new primitiveTypesExample(_simpleInteger, _lazyInteger, _arrayInteger, _optionInteger, _lazyArrayInteger, _lazyOptionInteger);
         |    }
         |    private int simpleInteger;
@@ -586,7 +625,10 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         new File("primitiveTypesNoLazyExample.java") ->
           """public final class primitiveTypesNoLazyExample implements java.io.Serializable {
             |
-            |    public static primitiveTypesNoLazyExample make(int _simpleInteger, int[] _arrayInteger) {
+            |    public static primitiveTypesNoLazyExample create(int _simpleInteger, int[] _arrayInteger) {
+            |        return new primitiveTypesNoLazyExample(_simpleInteger, _arrayInteger);
+            |    }
+            |    public static primitiveTypesNoLazyExample of(int _simpleInteger, int[] _arrayInteger) {
             |        return new primitiveTypesNoLazyExample(_simpleInteger, _arrayInteger);
             |    }
             |    private int simpleInteger;

--- a/library/src/test/scala/JsonSchemaExample.scala
+++ b/library/src/test/scala/JsonSchemaExample.scala
@@ -625,10 +625,16 @@ object PriorityLevel {
           |/** Meta information of a Greeting */
           |public final class GreetingHeader implements java.io.Serializable {
           |
-          |    public static GreetingHeader make(com.example.MyLazy<java.util.Date> _created, String _author) {
+          |    public static GreetingHeader create(com.example.MyLazy<java.util.Date> _created, String _author) {
           |        return new GreetingHeader(_created, _author);
           |    }
-          |    public static GreetingHeader make(com.example.MyLazy<java.util.Date> _created, com.example.PriorityLevel _priority, String _author) {
+          |    public static GreetingHeader of(com.example.MyLazy<java.util.Date> _created, String _author) {
+          |        return new GreetingHeader(_created, _author);
+          |    }
+          |    public static GreetingHeader create(com.example.MyLazy<java.util.Date> _created, com.example.PriorityLevel _priority, String _author) {
+          |        return new GreetingHeader(_created, _priority, _author);
+          |    }
+          |    public static GreetingHeader of(com.example.MyLazy<java.util.Date> _created, com.example.PriorityLevel _priority, String _author) {
           |        return new GreetingHeader(_created, _priority, _author);
           |    }
           |    /** Creation date */
@@ -703,10 +709,16 @@ object PriorityLevel {
         """package com.example;
           |/** A Greeting with attachments */
           |public final class GreetingWithAttachments extends com.example.Greetings {
-          |    public static GreetingWithAttachments make(com.example.MyLazy<String> _message, java.io.File[] _attachments) {
+          |    public static GreetingWithAttachments create(com.example.MyLazy<String> _message, java.io.File[] _attachments) {
           |        return new GreetingWithAttachments(_message, _attachments);
           |    }
-          |    public static GreetingWithAttachments make(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, java.io.File[] _attachments) {
+          |    public static GreetingWithAttachments of(com.example.MyLazy<String> _message, java.io.File[] _attachments) {
+          |        return new GreetingWithAttachments(_message, _attachments);
+          |    }
+          |    public static GreetingWithAttachments create(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, java.io.File[] _attachments) {
+          |        return new GreetingWithAttachments(_message, _header, _attachments);
+          |    }
+          |    public static GreetingWithAttachments of(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, java.io.File[] _attachments) {
           |        return new GreetingWithAttachments(_message, _header, _attachments);
           |    }
           |    /** The files attached to the greeting */
@@ -774,10 +786,16 @@ public abstract class GreetingExtra extends com.example.Greetings {
         """package com.example;
 public final class GreetingExtraImpl extends com.example.GreetingExtra {
 
-    public static GreetingExtraImpl make(com.example.MyLazy<String> _message, String[] _extra, String _x) {
+    public static GreetingExtraImpl create(com.example.MyLazy<String> _message, String[] _extra, String _x) {
         return new GreetingExtraImpl(_message, _extra, _x);
     }
-    public static GreetingExtraImpl make(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, String[] _extra, String _x) {
+    public static GreetingExtraImpl of(com.example.MyLazy<String> _message, String[] _extra, String _x) {
+        return new GreetingExtraImpl(_message, _extra, _x);
+    }
+    public static GreetingExtraImpl create(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, String[] _extra, String _x) {
+        return new GreetingExtraImpl(_message, _header, _extra, _x);
+    }
+    public static GreetingExtraImpl of(com.example.MyLazy<String> _message, com.example.GreetingHeader _header, String[] _extra, String _x) {
         return new GreetingExtraImpl(_message, _header, _extra, _x);
     }
     private String x;
@@ -865,10 +883,16 @@ public final class GreetingExtraImpl extends com.example.GreetingExtra {
         """package com.example;
           |/** A Greeting in its simplest form */
           |public final class SimpleGreeting extends com.example.Greetings {
-          |    public static SimpleGreeting make(com.example.MyLazy<String> _message) {
+          |    public static SimpleGreeting create(com.example.MyLazy<String> _message) {
           |        return new SimpleGreeting(_message);
           |    }
-          |    public static SimpleGreeting make(com.example.MyLazy<String> _message, com.example.GreetingHeader _header) {
+          |    public static SimpleGreeting of(com.example.MyLazy<String> _message) {
+          |        return new SimpleGreeting(_message);
+          |    }
+          |    public static SimpleGreeting create(com.example.MyLazy<String> _message, com.example.GreetingHeader _header) {
+          |        return new SimpleGreeting(_message, _header);
+          |    }
+          |    public static SimpleGreeting of(com.example.MyLazy<String> _message, com.example.GreetingHeader _header) {
           |        return new SimpleGreeting(_message, _header);
           |    }
           |    protected SimpleGreeting(com.example.MyLazy<String> _message) {
@@ -976,7 +1000,7 @@ implicit lazy val GreetingExtraImplFormat: JsonFormat[com.example.GreetingExtraI
       val extra = unbuilder.readField[Array[String]]("extra")
       val x = unbuilder.readField[String]("x")
       unbuilder.endObject()
-      com.example.GreetingExtraImpl.make(mkLazy(message), header, extra, x)
+      com.example.GreetingExtraImpl.of(mkLazy(message), header, extra, x)
       case None =>
       deserializationError("Expected JsObject but found None")
     }

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/src/main/scala/com/foo/Example.scala
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/src/main/scala/com/foo/Example.scala
@@ -7,10 +7,10 @@ import com.example._
 
 object Example extends App {
   import generated.CustomProtocol._
-  val g0: Greeting = SimpleGreeting.make("Hello")
-  val g1: Greeting = SimpleGreeting.make("Hello", Optional.empty[Integer]())
-  val g21: Greeting = GreetingWithAttachments.make("Hello", Array.empty)
-  val g3: Greeting = GreetingWithOption.make("Hello", Optional.ofNullable("foo"))
+  val g0: Greeting = SimpleGreeting.of("Hello")
+  val g1: Greeting = SimpleGreeting.of("Hello", Optional.empty[Integer]())
+  val g21: Greeting = GreetingWithAttachments.of("Hello", Array.empty)
+  val g3: Greeting = GreetingWithOption.of("Hello", Optional.ofNullable("foo"))
 
   println(CompactPrinter(Converter.toJson(g0).get))
   println(Converter.fromJson[Greeting](Converter.toJson(g0).get).get)

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/src/main/scala/com/foo/Example.scala
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/src/main/scala/com/foo/Example.scala
@@ -9,7 +9,7 @@ object Example extends App {
   import generated.CustomProtocol._
   val g0: Greeting = SimpleGreeting("Hello")
   val g1: Greeting = SimpleGreeting("Hello", Optional.empty[java.lang.Integer]())
-  val g21: Greeting = GreetingWithAttachments.make("Hello", Array.empty)
+  val g21: Greeting = GreetingWithAttachments.of("Hello", Array.empty)
   val g3: Greeting = GreetingWithOption("Hello", Optional.ofNullable("foo"))
 
   println(CompactPrinter(Converter.toJson(g0).get))


### PR DESCRIPTION
In actual usage make stands out in Scala.
I wish we could use apply, but that doesn't work for static methods.
I am now generating both `create` and `of`. For most cases, I would prefer the `of`.