### PR TITLE
Change the apply overloads codegen to use the private constructors

### DIFF
--- a/library/src/test/scala/GCodeGenSpec.scala
+++ b/library/src/test/scala/GCodeGenSpec.scala
@@ -1,7 +1,7 @@
 package sbt.contraband
 
 import org.scalatest._
-import ast.{ Definition => _ , _ }
+import sbt.contraband.ast._
 
 abstract class GCodeGenSpec(language: String) extends FlatSpec with Matchers with EqualLines {
   implicit def typeDefinitions2Document(ds: List[TypeDefinition]): Document =

--- a/library/src/test/scala/GraphQLMixedCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLMixedCodeGenSpec.scala
@@ -105,7 +105,7 @@ final class SimpleGreeting private (
   }
 }
 object SimpleGreeting {
-  def apply(message: String): SimpleGreeting = new SimpleGreeting(message, java.util.Optional.ofNullable[String]("1"))
+  def apply(message: String): SimpleGreeting = new SimpleGreeting(message)
   def apply(message: String, s: java.util.Optional[String]): SimpleGreeting = new SimpleGreeting(message, s)
   def apply(message: String, s: String): SimpleGreeting = new SimpleGreeting(message, java.util.Optional.ofNullable[String](s))
 }

--- a/library/src/test/scala/GraphQLScalaCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLScalaCodeGenSpec.scala
@@ -122,7 +122,7 @@ class GraphQLScalaCodeGenSpec extends FlatSpec with Matchers with Inside with Eq
         |  }
         |}
         |object Growable {
-        |  def apply(): Growable = new Growable(Option(0))
+        |  def apply(): Growable = new Growable()
         |  def apply(field: Option[Int]): Growable = new Growable(field)
         |  def apply(field: Int): Growable = new Growable(Option(field))
         |}
@@ -165,9 +165,9 @@ class GraphQLScalaCodeGenSpec extends FlatSpec with Matchers with Inside with Eq
         |  }
         |}
         |object Foo {
-        |  def apply(): Foo = new Foo(None, Vector())
-        |  def apply(x: Option[Int]): Foo = new Foo(x, Vector())
-        |  def apply(x: Int): Foo = new Foo(Option(x), Vector())
+        |  def apply(): Foo = new Foo()
+        |  def apply(x: Option[Int]): Foo = new Foo(x)
+        |  def apply(x: Int): Foo = new Foo(Option(x))
         |  def apply(x: Option[Int], y: Vector[Int]): Foo = new Foo(x, y)
         |  def apply(x: Int, y: Vector[Int]): Foo = new Foo(Option(x), y)
         |}

--- a/library/src/test/scala/JsonScalaCodeGenSpec.scala
+++ b/library/src/test/scala/JsonScalaCodeGenSpec.scala
@@ -250,7 +250,7 @@ class JsonScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  }
         |}
         |object growableAddOneField {
-        |  def apply(): growableAddOneField = new growableAddOneField(0)
+        |  def apply(): growableAddOneField = new growableAddOneField()
         |  def apply(field: Int): growableAddOneField = new growableAddOneField(field)
         |}
         |""".stripMargin.unindent)
@@ -290,9 +290,9 @@ class JsonScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  }
         |}
         |object Foo {
-        |  def apply(): Foo = new Foo(Option(0), Vector(0))
-        |  def apply(x: Option[Int]): Foo = new Foo(x, Vector(0))
-        |  def apply(x: Int): Foo = new Foo(Option(x), Vector(0))
+        |  def apply(): Foo = new Foo()
+        |  def apply(x: Option[Int]): Foo = new Foo(x)
+        |  def apply(x: Int): Foo = new Foo(Option(x))
         |  def apply(x: Option[Int], y: Vector[Int]): Foo = new Foo(x, y)
         |  def apply(x: Int, y: Vector[Int]): Foo = new Foo(Option(x), y)
         |}

--- a/library/src/test/scala/JsonSchemaExample.scala
+++ b/library/src/test/scala/JsonSchemaExample.scala
@@ -470,7 +470,7 @@ final class SimpleGreeting private (
   }
 }
 object SimpleGreeting {
-  def apply(message: => String): SimpleGreeting = new SimpleGreeting(message, new com.example.GreetingHeader(new java.util.Date(), "Unknown"))
+  def apply(message: => String): SimpleGreeting = new SimpleGreeting(message)
   def apply(message: => String, header: com.example.GreetingHeader): SimpleGreeting = new SimpleGreeting(message, header)
 }
 
@@ -529,7 +529,7 @@ final class GreetingExtraImpl private (
   }
 }
 object GreetingExtraImpl {
-  def apply(message: com.example.Lazy[String], extra: Array[String], x: String): GreetingExtraImpl = new GreetingExtraImpl(message, new com.example.GreetingHeader(new java.util.Date(), "Unknown"), extra, x)
+  def apply(message: com.example.Lazy[String], extra: Array[String], x: String): GreetingExtraImpl = new GreetingExtraImpl(message, extra, x)
   def apply(message: com.example.Lazy[String], header: com.example.GreetingHeader, extra: Array[String], x: String): GreetingExtraImpl = new GreetingExtraImpl(message, header, extra, x)
 }
 
@@ -565,7 +565,7 @@ final class GreetingWithAttachments private (
   }
 }
 object GreetingWithAttachments {
-  def apply(message: => String, attachments: Vector[java.io.File]): GreetingWithAttachments = new GreetingWithAttachments(message, new com.example.GreetingHeader(new java.util.Date(), "Unknown"), attachments)
+  def apply(message: => String, attachments: Vector[java.io.File]): GreetingWithAttachments = new GreetingWithAttachments(message, attachments)
   def apply(message: => String, header: com.example.GreetingHeader, attachments: Vector[java.io.File]): GreetingWithAttachments = new GreetingWithAttachments(message, header, attachments)
 }
 
@@ -605,7 +605,7 @@ final class GreetingHeader private (
 object GreetingHeader {
   val default: GreetingHeader =
   new GreetingHeader(new java.util.Date(), com.example.PriorityLevel.Medium, scala.sys.props("user.name")
-  def apply(created: => java.util.Date, author: String): GreetingHeader = new GreetingHeader(created, com.example.PriorityLevel.Medium, author)
+  def apply(created: => java.util.Date, author: String): GreetingHeader = new GreetingHeader(created, author)
   def apply(created: => java.util.Date, priority: com.example.PriorityLevel, author: String): GreetingHeader = new GreetingHeader(created, priority, author)
 }
 


### PR DESCRIPTION
This ensures that the private constructors are generated, which in turn
ensures that new versions of contraband types are bincompat.