### PR TITLE
Honour the "generateCodec" directive when getting all the formats for a schema

### DIFF
--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -219,8 +219,8 @@ class CodecCodeGen(codecParents: List[String],
 
   private def getAllFormatsForSchema(s: Document): List[String] =
     getAllRequiredFormats(s, (s.definitions collect {
-      case td: TypeDefinition => td
-    }).toList)
+      case td: TypeDefinition if getGenerateCodec(td.directives) => td
+    }))
 
   /**
    * Returns the list of fully qualified codec names that we (transitively) need to generate a codec for `ds`,


### PR DESCRIPTION
Tested locally with local changes in sbt/lm.