### PR TITLE
Fixes equal / hashCode inconsistencies

### DIFF
--- a/library/src/main/scala/sbt/contraband/JavaCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/JavaCodeGen.scala
@@ -355,6 +355,8 @@ class JavaCodeGen(lazyInterface: String, optionalInterface: String,
 
   private def hashCode(f: FieldDefinition): String =
     if (isPrimitive(f.fieldType)) s"(new ${boxedType(f.fieldType.name)}(${f.name}())).hashCode()"
+    else if (isPrimitiveArray(f.fieldType)) s"java.util.Arrays.hashCode(${f.name}())"
+    else if (f.fieldType.isListType) s"java.util.Arrays.deepHashCode(${f.name}())"
     else s"${f.name}().hashCode()"
 
   private def genHashCode(cl: RecordLikeDefinition) = {

--- a/library/src/test/scala/GraphQLJavaCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLJavaCodeGenSpec.scala
@@ -239,7 +239,7 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |        }
         |    }
         |    public int hashCode() {
-        |        return 37 * (37 * (37 * (17 + "com.example.Foo".hashCode()) + x().hashCode()) + y().hashCode());
+        |        return 37 * (37 * (37 * (17 + "com.example.Foo".hashCode()) + x().hashCode()) + java.util.Arrays.hashCode(y()));
         |    }
         |    public String toString() {
         |        return "Foo("  + "x: " + x() + ", " + "y: " + y() + ")";

--- a/library/src/test/scala/GraphQLJavaCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLJavaCodeGenSpec.scala
@@ -69,7 +69,7 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |            return false;
         |        } else {
         |            TypeExample o = (TypeExample)obj;
-        |            return field().equals(o.field());
+        |            return this.field().equals(o.field());
         |        }
         |    }
         |    public int hashCode() {
@@ -136,7 +136,7 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |            return false;
         |        } else {
         |            Growable o = (Growable)obj;
-        |            return field().equals(o.field());
+        |            return this.field().equals(o.field());
         |        }
         |    }
         |    public int hashCode() {
@@ -235,7 +235,7 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |            return false;
         |        } else {
         |            Foo o = (Foo)obj;
-        |            return x().equals(o.x()) && java.util.Arrays.equals(y(), o.y());
+        |            return this.x().equals(o.x()) && java.util.Arrays.equals(this.y(), o.y());
         |        }
         |    }
         |    public int hashCode() {
@@ -278,7 +278,7 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |            return false;
         |        } else {
         |            InterfaceExample o = (InterfaceExample)obj;
-        |            return field().equals(o.field());
+        |            return this.field().equals(o.field());
         |        }
         |    }
         |    public int hashCode() {
@@ -334,7 +334,7 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |            return false;
         |        } else {
         |            ChildType o = (ChildType)obj;
-        |            return name().equals(o.name()) && field().equals(o.field());
+        |            return this.name().equals(o.name()) && this.field().equals(o.field());
         |        }
         |    }
         |    public int hashCode() {
@@ -380,7 +380,7 @@ class GraphQLJavaCodeGenSpec extends FlatSpec with Matchers with Inside with Equ
         |            return false;
         |        } else {
         |            IntfExample o = (IntfExample)obj;
-        |            return field().equals(o.field());
+        |            return this.field().equals(o.field());
         |        }
         |    }
         |    public int hashCode() {

--- a/library/src/test/scala/GraphQLMixedCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLMixedCodeGenSpec.scala
@@ -59,7 +59,7 @@ public abstract class Greeting implements java.io.Serializable {
             return false;
         } else {
             Greeting o = (Greeting)obj;
-            return message().equals(o.message()) && s().equals(o.s());
+            return this.message().equals(o.message()) && this.s().equals(o.s());
         }
     }
     public int hashCode() {
@@ -82,11 +82,11 @@ final class SimpleGreeting private (
   s: java.util.Optional[String]) extends com.example.Greeting(message, s) with Serializable {
   private def this(message: String) = this(message, java.util.Optional.ofNullable[String]("1"))
   override def equals(o: Any): Boolean = o match {
-    case x: SimpleGreeting => (this.message == x.message) && (this.s == x.s)
+    case x: SimpleGreeting => this.message.equals(x.message) && this.s.equals(x.s)
     case _ => false
   }
   override def hashCode: Int = {
-    37 * (37 * (37 * (17 + "com.example.SimpleGreeting".##) + message.##) + s.##)
+    37 * (37 * (37 * (17 + "com.example.SimpleGreeting".##) +  message.hashCode()) +  s.hashCode())
   }
   override def toString: String = {
     "SimpleGreeting(" + message + ", " + s + ")"

--- a/library/src/test/scala/JsonJavaCodeGenSpec.scala
+++ b/library/src/test/scala/JsonJavaCodeGenSpec.scala
@@ -455,7 +455,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             |        }
             |    }
             |    public int hashCode() {
-            |        return 37 * (37 * (37 * (17 + "Foo".hashCode()) + x().hashCode()) + y().hashCode());
+            |        return 37 * (37 * (37 * (17 + "Foo".hashCode()) + x().hashCode()) + java.util.Arrays.hashCode(y()));
             |    }
             |    public String toString() {
             |        return "Foo("  + "x: " + x() + ", " + "y: " + y() + ")";
@@ -662,7 +662,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             |        }
             |    }
             |    public int hashCode() {
-            |        return 37 * (37 * (37 * (17 + "primitiveTypesNoLazyExample".hashCode()) + (new Integer(simpleInteger())).hashCode()) + arrayInteger().hashCode());
+            |        return 37 * (37 * (37 * (17 + "primitiveTypesNoLazyExample".hashCode()) + (new Integer(simpleInteger())).hashCode()) + java.util.Arrays.hashCode(arrayInteger()));
             |    }
             |    public String toString() {
             |        return "primitiveTypesNoLazyExample("  + "simpleInteger: " + simpleInteger() + ", " + "arrayInteger: " + arrayInteger() + ")";

--- a/library/src/test/scala/JsonJavaCodeGenSpec.scala
+++ b/library/src/test/scala/JsonJavaCodeGenSpec.scala
@@ -45,7 +45,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         |            return false;
         |        } else {
         |            simpleInterfaceExample o = (simpleInterfaceExample)obj;
-        |            return field().equals(o.field());
+        |            return this.field().equals(o.field());
         |        }
         |    }
         |    public int hashCode() {
@@ -81,7 +81,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         |            return false;
         |        } else {
         |            oneChildInterfaceExample o = (oneChildInterfaceExample)obj;
-        |            return (field() == o.field());
+        |            return (this.field() == o.field());
         |        }
         |    }
         |    public int hashCode() {
@@ -120,7 +120,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
         |            return false;
         |        } else {
         |            childRecord o = (childRecord)obj;
-        |            return (field() == o.field()) && (x() == o.x());
+        |            return (this.field() == o.field()) && (this.x() == o.x());
         |        }
         |    }
         |    public int hashCode() {
@@ -248,7 +248,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             |            return false;
             |        } else {
             |            generateArgDocExample o = (generateArgDocExample)obj;
-            |            return (field() == o.field());
+            |            return (this.field() == o.field());
             |        }
             |    }
             |    public int hashCode() {
@@ -296,7 +296,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             |            return false;
             |        } else {
             |            simpleRecordExample o = (simpleRecordExample)obj;
-            |            return field().equals(o.field());
+            |            return this.field().equals(o.field());
             |        }
             |    }
             |    public int hashCode() {
@@ -351,7 +351,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             |            return false;
             |        } else {
             |            growableAddOneField o = (growableAddOneField)obj;
-            |            return (field() == o.field());
+            |            return (this.field() == o.field());
             |        }
             |    }
             |    public int hashCode() {
@@ -451,7 +451,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             |            return false;
             |        } else {
             |            Foo o = (Foo)obj;
-            |            return x().equals(o.x()) && java.util.Arrays.equals(y(), o.y());
+            |            return this.x().equals(o.x()) && java.util.Arrays.equals(this.y(), o.y());
             |        }
             |    }
             |    public int hashCode() {
@@ -506,7 +506,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             return false;
         } else {
             primitiveTypesExample2 o = (primitiveTypesExample2)obj;
-            return (smallBoolean() == o.smallBoolean()) && (bigBoolean() == o.bigBoolean());
+            return (this.smallBoolean() == o.smallBoolean()) && (this.bigBoolean() == o.bigBoolean());
         }
     }
     public int hashCode() {
@@ -658,7 +658,7 @@ class JsonJavaCodeGenSpec extends GCodeGenSpec("Java") {
             |            return false;
             |        } else {
             |            primitiveTypesNoLazyExample o = (primitiveTypesNoLazyExample)obj;
-            |            return (simpleInteger() == o.simpleInteger()) && java.util.Arrays.equals(arrayInteger(), o.arrayInteger());
+            |            return (this.simpleInteger() == o.simpleInteger()) && java.util.Arrays.equals(this.arrayInteger(), o.arrayInteger());
             |        }
             |    }
             |    public int hashCode() {

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/src/main/contraband/greeting.contra
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/src/main/contraband/greeting.contra
@@ -35,3 +35,7 @@ type Person {
   name: String!
   age: Int
 }
+
+type GreetingList {
+  greetings: [com.example.Greeting]!
+}

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/src/main/scala/com/foo/Example.scala
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/src/main/scala/com/foo/Example.scala
@@ -11,6 +11,8 @@ object Example extends App {
   val g1: Greeting = SimpleGreeting.of("Hello", Optional.empty[Integer]())
   val g21: Greeting = GreetingWithAttachments.of("Hello", Array.empty)
   val g3: Greeting = GreetingWithOption.of("Hello", Optional.ofNullable("foo"))
+  val gl1: GreetingList = GreetingList.of(Array(g0))
+  val gl2: GreetingList = GreetingList.of(Array(g0))
 
   println(CompactPrinter(Converter.toJson(g0).get))
   println(Converter.fromJson[Greeting](Converter.toJson(g0).get).get)
@@ -19,4 +21,6 @@ object Example extends App {
   assert(Converter.fromJson[Greeting](Converter.toJson(g1).get).get == g1)
   assert(Converter.fromJson[Greeting](Converter.toJson(g21).get).get == g21)
   assert(Converter.fromJson[Greeting](Converter.toJson(g3).get).get == g3)
+  assert(gl1 == gl2)
+  assert(gl1.## == gl2.##)
 }

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/src/main/contraband/greeting.contra
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/src/main/contraband/greeting.contra
@@ -13,7 +13,7 @@ type SimpleGreeting implements Greeting @target(Scala) {
   number: Int @since("0.1.0")
 }
 
-type GreetingWithAttachments implements Greeting {
+type GreetingWithAttachments implements Greeting @target(Scala) {
   message: String!
   number: Int @since("0.1.0")
   attachments: [java.io.File]

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/src/main/scala/com/foo/Example.scala
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/src/main/scala/com/foo/Example.scala
@@ -9,7 +9,8 @@ object Example extends App {
   import generated.CustomProtocol._
   val g0: Greeting = SimpleGreeting("Hello")
   val g1: Greeting = SimpleGreeting("Hello", Optional.empty[java.lang.Integer]())
-  val g21: Greeting = GreetingWithAttachments.of("Hello", Array.empty)
+  val g21: Greeting = GreetingWithAttachments("Hello", Array.empty)
+  val g22: Greeting = GreetingWithAttachments("Hello", Array.empty)
   val g3: Greeting = GreetingWithOption("Hello", Optional.ofNullable("foo"))
 
   println(CompactPrinter(Converter.toJson(g0).get))
@@ -17,6 +18,7 @@ object Example extends App {
 
   assert(Converter.fromJson[Greeting](Converter.toJson(g0).get).get == g0)
   assert(Converter.fromJson[Greeting](Converter.toJson(g1).get).get == g1)
+  assert(g21 == g22)
   assert(Converter.fromJson[Greeting](Converter.toJson(g21).get).get == g21)
   assert(Converter.fromJson[Greeting](Converter.toJson(g3).get).get == g3)
 }

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/src/main/contraband/greeting.contra
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/src/main/contraband/greeting.contra
@@ -36,3 +36,7 @@ type Person {
   name: String!
   age: Int
 }
+
+type GreetingList {
+  greetings: [com.example.Greeting]!
+}

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/src/main/scala/com/foo/Example.scala
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/src/main/scala/com/foo/Example.scala
@@ -11,6 +11,8 @@ object Example extends App {
   val g1: Greeting = SimpleGreeting("Hello", None)
   val g21: Greeting = GreetingWithAttachments("Hello", Vector.empty)
   val g3: Greeting = GreetingWithOption("Hello", Option("foo"))
+  val gl1: GreetingList = GreetingList(Vector(g0))
+  val gl2: GreetingList = GreetingList(Vector(g0))
 
   val json = CompactPrinter(Converter.toJson(g0).get)
   println(json)
@@ -32,4 +34,7 @@ object Example extends App {
   val json4 = CompactPrinter(Converter.toJson(f0).get)
   println(json4)
   assert(Converter.fromJson[Fruit](Converter.toJson(f0).get).get == f0)
+
+  assert(gl1 == gl2)
+  assert(gl1.## == gl2.##)
 }


### PR DESCRIPTION
Fixes #119

1. Fixes equal/hashCode inconsistencies in Java.
2. Generate Array deep comparison code for Scala too since it does use Array when Java and Scala are mixed.
