### PR TITLE
Revert "Make the copy method protected[this] so it can be defined and uses in the parent"

### DIFF
--- a/docs/02-code-generation.md
+++ b/docs/02-code-generation.md
@@ -46,7 +46,7 @@ final class Person private (
   override def toString: String = {
     "Person(" + name + ", " + age + ")"
   }
-  protected[this] def copy(name: String = name, age: Option[Int] = age): Person = {
+  private[this] def copy(name: String = name, age: Option[Int] = age): Person = {
     new Person(name, age)
   }
   def withName(name: String): Person = {

--- a/docs/ja/02-code-generation.md
+++ b/docs/ja/02-code-generation.md
@@ -46,7 +46,7 @@ final class Person private (
   override def toString: String = {
     "Person(" + name + ", " + age + ")"
   }
-  protected[this] def copy(name: String = name, age: Option[Int] = age): Person = {
+  private[this] def copy(name: String = name, age: Option[Int] = age): Person = {
     new Person(name, age)
   }
   def withName(name: String): Person = {

--- a/library/src/main/scala/sbt/contraband/ScalaCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/ScalaCodeGen.scala
@@ -443,7 +443,7 @@ class ScalaCodeGen(javaLazy: String, javaOptional: String, instantiateJavaOption
     def genParam(f: FieldDefinition) = s"${bq(f.name)}: ${genRealTpe(f.fieldType, isParam = true, intfLang)} = ${bq(f.name)}"
     val params = allFields map genParam mkString ", "
     val constructorCall = allFields map (f => bq(f.name)) mkString ", "
-    s"""protected[this] def copy($params): ${r.name} = {
+    s"""private[this] def copy($params): ${r.name} = {
        |  new ${r.name}($constructorCall)
        |}""".stripMargin
   }

--- a/library/src/test/scala/GraphQLMixedCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLMixedCodeGenSpec.scala
@@ -91,7 +91,7 @@ final class SimpleGreeting private (
   override def toString: String = {
     "SimpleGreeting(" + message + ", " + s + ")"
   }
-  protected[this] def copy(message: String = message, s: java.util.Optional[String] = s): SimpleGreeting = {
+  private[this] def copy(message: String = message, s: java.util.Optional[String] = s): SimpleGreeting = {
     new SimpleGreeting(message, s)
   }
   def withMessage(message: String): SimpleGreeting = {

--- a/library/src/test/scala/GraphQLScalaCodeGenSpec.scala
+++ b/library/src/test/scala/GraphQLScalaCodeGenSpec.scala
@@ -44,7 +44,7 @@ class GraphQLScalaCodeGenSpec extends FlatSpec with Matchers with Inside with Eq
         |  override def toString: String = {
         |    "TypeExample(" + field + ")"
         |  }
-        |  protected[this] def copy(field: Option[java.net.URL] = field): TypeExample = {
+        |  private[this] def copy(field: Option[java.net.URL] = field): TypeExample = {
         |    new TypeExample(field)
         |  }
         |  def withField(field: Option[java.net.URL]): TypeExample = {
@@ -79,7 +79,7 @@ class GraphQLScalaCodeGenSpec extends FlatSpec with Matchers with Inside with Eq
         |  override def toString: String = {
         |    "TypeExample(" + field + ")"
         |  }
-        |  protected[this] def copy(field: scala.collection.immutable.Map[String, String] = field): TypeExample = {
+        |  private[this] def copy(field: scala.collection.immutable.Map[String, String] = field): TypeExample = {
         |    new TypeExample(field)
         |  }
         |  def withField(field: scala.collection.immutable.Map[String, String]): TypeExample = {
@@ -111,7 +111,7 @@ class GraphQLScalaCodeGenSpec extends FlatSpec with Matchers with Inside with Eq
         |  override def toString: String = {
         |    "Growable(" + field + ")"
         |  }
-        |  protected[this] def copy(field: Option[Int] = field): Growable = {
+        |  private[this] def copy(field: Option[Int] = field): Growable = {
         |    new Growable(field)
         |  }
         |  def withField(field: Option[Int]): Growable = {
@@ -151,7 +151,7 @@ class GraphQLScalaCodeGenSpec extends FlatSpec with Matchers with Inside with Eq
         |  override def toString: String = {
         |    "Foo(" + x + ", " + y + ")"
         |  }
-        |  protected[this] def copy(x: Option[Int] = x, y: Vector[Int] = y): Foo = {
+        |  private[this] def copy(x: Option[Int] = x, y: Vector[Int] = y): Foo = {
         |    new Foo(x, y)
         |  }
         |  def withX(x: Option[Int]): Foo = {
@@ -209,7 +209,7 @@ class GraphQLScalaCodeGenSpec extends FlatSpec with Matchers with Inside with Eq
         |  override def toString: String = {
         |    "ChildType(" + name + ", " + field + ")"
         |  }
-        |  protected[this] def copy(name: Option[String] = name, field: Option[Int] = field): ChildType = {
+        |  private[this] def copy(name: Option[String] = name, field: Option[Int] = field): ChildType = {
         |    new ChildType(name, field)
         |  }
         |  def withName(name: Option[String]): ChildType = {

--- a/library/src/test/scala/JsonScalaCodeGenSpec.scala
+++ b/library/src/test/scala/JsonScalaCodeGenSpec.scala
@@ -84,7 +84,7 @@ class JsonScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "childRecord(" + field + ", " + x + ")"
         |  }
-        |  protected[this] def copy(field: Int = field, x: Int = x): childRecord = {
+        |  private[this] def copy(field: Int = field, x: Int = x): childRecord = {
         |    new childRecord(field, x)
         |  }
         |  def withField(field: Int): childRecord = {
@@ -149,7 +149,7 @@ class JsonScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "ChildRecord()"
         |  }
-        |  protected[this] def copy(): ChildRecord = {
+        |  private[this] def copy(): ChildRecord = {
         |    new ChildRecord()
         |  }
         |}
@@ -211,7 +211,7 @@ class JsonScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "simpleRecordExample(" + field + ")"
         |  }
-        |  protected[this] def copy(field: java.net.URL = field): simpleRecordExample = {
+        |  private[this] def copy(field: java.net.URL = field): simpleRecordExample = {
         |    new simpleRecordExample(field)
         |  }
         |  def withField(field: java.net.URL): simpleRecordExample = {
@@ -242,7 +242,7 @@ class JsonScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "growableAddOneField(" + field + ")"
         |  }
-        |  protected[this] def copy(field: Int = field): growableAddOneField = {
+        |  private[this] def copy(field: Int = field): growableAddOneField = {
         |    new growableAddOneField(field)
         |  }
         |  def withField(field: Int): growableAddOneField = {
@@ -276,7 +276,7 @@ class JsonScalaCodeGenSpec extends GCodeGenSpec("Scala") {
         |  override def toString: String = {
         |    "Foo(" + x + ", " + y + ")"
         |  }
-        |  protected[this] def copy(x: Option[Int] = x, y: Vector[Int] = y): Foo = {
+        |  private[this] def copy(x: Option[Int] = x, y: Vector[Int] = y): Foo = {
         |    new Foo(x, y)
         |  }
         |  def withX(x: Option[Int]): Foo = {
@@ -320,7 +320,7 @@ class JsonScalaCodeGenSpec extends GCodeGenSpec("Scala") {
   override def toString: String = {
     "primitiveTypesExample2(" + smallBoolean + ", " + bigBoolean + ")"
   }
-  protected[this] def copy(smallBoolean: Boolean = smallBoolean, bigBoolean: Boolean = bigBoolean): primitiveTypesExample2 = {
+  private[this] def copy(smallBoolean: Boolean = smallBoolean, bigBoolean: Boolean = bigBoolean): primitiveTypesExample2 = {
     new primitiveTypesExample2(smallBoolean, bigBoolean)
   }
   def withSmallBoolean(smallBoolean: Boolean): primitiveTypesExample2 = {
@@ -362,7 +362,7 @@ object primitiveTypesExample2 {
         |  override def toString: String = {
         |    super.toString // Avoid evaluating lazy members in toString to avoid circularity.
         |  }
-        |  protected[this] def copy(simpleInteger: Int = simpleInteger, lazyInteger: => Int = lazyInteger, arrayInteger: Vector[Int] = arrayInteger, optionInteger: Option[Int] = optionInteger, lazyArrayInteger: => Vector[Int] = lazyArrayInteger, lazyOptionInteger: => Option[Int] = lazyOptionInteger): primitiveTypesExample = {
+        |  private[this] def copy(simpleInteger: Int = simpleInteger, lazyInteger: => Int = lazyInteger, arrayInteger: Vector[Int] = arrayInteger, optionInteger: Option[Int] = optionInteger, lazyArrayInteger: => Vector[Int] = lazyArrayInteger, lazyOptionInteger: => Option[Int] = lazyOptionInteger): primitiveTypesExample = {
         |    new primitiveTypesExample(simpleInteger, lazyInteger, arrayInteger, optionInteger, lazyArrayInteger, lazyOptionInteger)
         |  }
         |  def withSimpleInteger(simpleInteger: Int): primitiveTypesExample = {
@@ -420,7 +420,7 @@ object primitiveTypesExample2 {
         |  override def toString: String = {
         |    "primitiveTypesNoLazyExample(" + simpleInteger + ", " + arrayInteger + ")"
         |  }
-        |  protected[this] def copy(simpleInteger: Int = simpleInteger, arrayInteger: Vector[Int] = arrayInteger): primitiveTypesNoLazyExample = {
+        |  private[this] def copy(simpleInteger: Int = simpleInteger, arrayInteger: Vector[Int] = arrayInteger): primitiveTypesNoLazyExample = {
         |    new primitiveTypesNoLazyExample(simpleInteger, arrayInteger)
         |  }
         |  def withSimpleInteger(simpleInteger: Int): primitiveTypesNoLazyExample = {

--- a/library/src/test/scala/JsonSchemaExample.scala
+++ b/library/src/test/scala/JsonSchemaExample.scala
@@ -459,7 +459,7 @@ final class SimpleGreeting private (
   override def toString: String = {
     super.toString // Avoid evaluating lazy members in toString to avoid circularity.
   }
-  protected[this] def copy(message: => String = message, header: com.example.GreetingHeader = header): SimpleGreeting = {
+  private[this] def copy(message: => String = message, header: com.example.GreetingHeader = header): SimpleGreeting = {
     new SimpleGreeting(message, header)
   }
   def withMessage(message: => String): SimpleGreeting = {
@@ -512,7 +512,7 @@ final class GreetingExtraImpl private (
   override def toString: String = {
     return "Welcome, extra implosion!";
   }
-  protected[this] def copy(message: com.example.Lazy[String] = message, header: com.example.GreetingHeader = header, extra: Array[String] = extra, x: String = x): GreetingExtraImpl = {
+  private[this] def copy(message: com.example.Lazy[String] = message, header: com.example.GreetingHeader = header, extra: Array[String] = extra, x: String = x): GreetingExtraImpl = {
     new GreetingExtraImpl(message, header, extra, x)
   }
   def withMessage(message: com.example.Lazy[String]): GreetingExtraImpl = {
@@ -551,7 +551,7 @@ final class GreetingWithAttachments private (
   override def toString: String = {
     super.toString // Avoid evaluating lazy members in toString to avoid circularity.
   }
-  protected[this] def copy(message: => String = message, header: com.example.GreetingHeader = header, attachments: Vector[java.io.File] = attachments): GreetingWithAttachments = {
+  private[this] def copy(message: => String = message, header: com.example.GreetingHeader = header, attachments: Vector[java.io.File] = attachments): GreetingWithAttachments = {
     new GreetingWithAttachments(message, header, attachments)
   }
   def withMessage(message: => String): GreetingWithAttachments = {
@@ -589,7 +589,7 @@ final class GreetingHeader private (
   override def toString: String = {
     super.toString // Avoid evaluating lazy members in toString to avoid circularity.
   }
-  protected[this] def copy(created: => java.util.Date = created, priority: com.example.PriorityLevel = priority, author: String = author): GreetingHeader = {
+  private[this] def copy(created: => java.util.Date = created, priority: com.example.PriorityLevel = priority, author: String = author): GreetingHeader = {
     new GreetingHeader(created, priority, author)
   }
   def withCreated(created: => java.util.Date): GreetingHeader = {


### PR DESCRIPTION
This reverts commit 76cd9a2219ec4c682fee99bafd4fa26285c7361a.

At the time I thought that these were required to migrate LM's data
types to Contraband. I was mistaken: I can use the generated "with*"
methods instead.