### PR TITLE
Cache generated output per Scala version

### DIFF
--- a/plugin/src/main/scala/ContrabandPlugin.scala
+++ b/plugin/src/main/scala/ContrabandPlugin.scala
@@ -1,10 +1,9 @@
 package sbt.contraband
 
+import sbt.Keys._
 import sbt._
-import Keys._
-import ast._
-import parser.{ JsonParser, SchemaParser }
-import scala.util.Success
+import sbt.contraband.ast._
+import sbt.contraband.parser.{JsonParser, SchemaParser}
 
 object ContrabandPlugin extends AutoPlugin {
 
@@ -201,7 +200,13 @@ object Generate {
       scalaFileNames, scalaSealInterface, scalaPrivateConstructor, wrapOption,
       codecParents, instantiateJavaLazy, instantiateJavaOptional, formatsForType, s.log)
 
-    val f = FileFunction.cached(s.cacheDirectory / scalaVersion / "gen-api", FilesInfo.hash) { _ => gen().toSet } // TODO: check if output directory changed
+    val scalaVersionSubDir = scalaVersion match {
+      case VersionNumber(Seq(x, y, _*), _, _) => s"scala-$x.$y"
+      case _ => throw new IllegalArgumentException(s"Invalid Scala version: '$scalaVersion'")
+    }
+    val cacheDirectory = s.cacheDirectory / scalaVersionSubDir / "gen-api"
+
+    val f = FileFunction.cached(cacheDirectory, FilesInfo.hash) { _ => gen().toSet } // TODO: check if output directory changed
     f(definitions.toSet).toSeq
   }
 }

--- a/plugin/src/main/scala/ContrabandPlugin.scala
+++ b/plugin/src/main/scala/ContrabandPlugin.scala
@@ -68,6 +68,7 @@ object ContrabandPlugin extends AutoPlugin {
           (contrabandScalaFileNames in generateContrabands).value,
           (contrabandScalaSealInterface in generateContrabands).value,
           (contrabandScalaPrivateConstructor in generateContrabands).value,
+          (scalaVersion in generateContrabands).value,
           (contrabandWrapOption in generateContrabands).value,
           (contrabandCodecParents in generateContrabands).value,
           (contrabandInstantiateJavaLazy in generateContrabands).value,
@@ -188,6 +189,7 @@ object Generate {
     scalaFileNames: Any => File,
     scalaSealInterface: Boolean,
     scalaPrivateConstructor: Boolean,
+    scalaVersion: String,
     wrapOption: Boolean,
     codecParents: List[String],
     instantiateJavaLazy: String => String,
@@ -198,7 +200,8 @@ object Generate {
     def gen() = generate(createDatatypes, createCodecs, definitions, target, javaLazy, javaOption, scalaArray,
       scalaFileNames, scalaSealInterface, scalaPrivateConstructor, wrapOption,
       codecParents, instantiateJavaLazy, instantiateJavaOptional, formatsForType, s.log)
-    val f = FileFunction.cached(s.cacheDirectory / "gen-api", FilesInfo.hash) { _ => gen().toSet } // TODO: check if output directory changed
+
+    val f = FileFunction.cached(s.cacheDirectory / scalaVersion / "gen-api", FilesInfo.hash) { _ => gen().toSet } // TODO: check if output directory changed
     f(definitions.toSet).toSeq
   }
 }


### PR DESCRIPTION
Attempting to fix #137

I tried to do something similar in a local project and it seemed promising. I used:
```sbt
lazy val myProject = (project in file("myProject")).enablePlugins(ContrabandPlugin).settings(
  inConfig(Compile)(Seq(
    scalacOptions := Seq(),  // this avoids turning warnings to compiler errors
    // This avoids the "not found: type Builder" errors in the compiled output
    libraryDependencies ++= (generateContrabands / contrabandCodecsDependencies).value,
    generateContrabands := {
      val result = generateContrabands.value
      val s = streams.value
      (s.cacheDirectory / "gen-api").delete()
      result
    }
  ))
)
```
This produces two distinct `src_managed` directories with separate class files.

NOTE: I was having trouble getting the code to compile, but that was because my failed results were cached without the `contrabandCodecsDependencies` present. When I cleaned the target directory and re-ran `compile` it worked as expected.

Anyway, I tried to push something I think will fix it, but I am seeing the following error locally on master when I run the tests:
```
[error] Modules were resolved with conflicting cross-version suffixes in {file:/Users/jeffmay/code/personal/contraband/}plugin:
[error]    org.spire-math:jawn-parser _2.12, _2.10
[error]    org.json4s:json4s-ast _2.12, _2.10
[error]    org.json4s:json4s-core _2.12, _2.10
[trace] Stack trace suppressed: run last plugin/*:update for the full output.
[error] (plugin/*:update) Conflicting cross-version suffixes in: org.spire-math:jawn-parser, org.json4s:json4s-ast, org.json4s:json4s-core
[error] Total time: 1 s, completed Jul 12, 2019 5:36:49 PM
```

Does this look right to you? Any good way to test this locally?