### PR TITLE
use \n for line endings

### DIFF
--- a/library/src/main/scala/sbt/contraband/CodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodeGen.scala
@@ -1,6 +1,5 @@
 package sbt.contraband
 
-import scala.compat.Platform.EOL
 import java.io.File
 import scala.collection.immutable.ListMap
 import ast.{ Definition => _, _ }
@@ -10,6 +9,10 @@ import AstUtil._
  * The base for code generators.
  */
 abstract class CodeGenerator {
+
+  //make sure that EOL is *not* platform dependent by default, otherwise
+  //the output of contraband will be platform dependent too.
+  val EOL = "\n"
 
   implicit class ListMapOp[T](m: ListMap[T, String]) {
     def merge(o: ListMap[T, String]): ListMap[T, String] =

--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -1,6 +1,5 @@
 package sbt.contraband
 
-import scala.compat.Platform.EOL
 import java.io.File
 import scala.collection.immutable.ListMap
 import CodeGen.bq
@@ -22,6 +21,7 @@ class CodecCodeGen(codecParents: List[String],
   formatsForType: ast.Type => List[String],
   includedSchemas: List[Document]) extends CodeGenerator {
   import CodecCodeGen._
+
   implicit object indentationConfiguration extends IndentationConfiguration {
     override val indentElement = "  "
     override def augmentIndentAfterTrigger(s: String) =

--- a/library/src/main/scala/sbt/contraband/Indentation.scala
+++ b/library/src/main/scala/sbt/contraband/Indentation.scala
@@ -1,13 +1,12 @@
 package sbt.contraband
 
-import scala.compat.Platform.EOL
-
 /**
  * Implementation of a string buffer which takes care of indentation (according to `augmentIndentTrigger`,
  * `augmentIndentAfterTrigger`, `reduceIndentTrigger` and `reduceIndentAfterTrigger`) as text is added.
  */
 class IndentationAwareBuffer(val config: IndentationConfiguration, private var level: Int = 0, private var inJavadoc: Boolean = false) {
   private val buffer: StringBuilder = new StringBuilder
+  val EOL = "\n"
 
   /** Add all the lines of `it` to the buffer. */
   def +=(it: Iterator[String]): Unit = it foreach append

--- a/library/src/main/scala/sbt/contraband/JavaCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/JavaCodeGen.scala
@@ -1,6 +1,5 @@
 package sbt.contraband
 
-import scala.compat.Platform.EOL
 import java.io.File
 import scala.collection.immutable.ListMap
 import ast._

--- a/library/src/main/scala/sbt/contraband/ScalaCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/ScalaCodeGen.scala
@@ -1,6 +1,5 @@
 package sbt.contraband
 
-import scala.compat.Platform.EOL
 import java.io.File
 import scala.collection.immutable.ListMap
 import CodeGen.bq


### PR DESCRIPTION
having platform-dependent line endings makes contraband behave platform dependently. That's undesirable for reproducibility and problematic in cases where contraband output is part of some VCS where people on different platforms collaborate.

fixes #122