### PR TITLE
Enumerate transitive self types

### DIFF
--- a/library/src/test/scala/GraphQLExample.scala
+++ b/library/src/test/scala/GraphQLExample.scala
@@ -72,6 +72,23 @@ type ChildType implements InterfaceExample {
 }
 """
 
+  val intfExampleWithEmbed = """
+package com.example @target(Scala)
+@codecPackage("generated")
+
+## Example of an interface
+interface InterfaceExample {}
+
+type ChildType implements InterfaceExample {
+  detail: [com.example.TestItemDetail]
+}
+
+type TestItemDetail {
+  ## Indicates whether the event represents a test success, failure, error, skipped, ignored, canceled, pending.
+  status: com.example.Status!
+}
+"""
+
   val twoLevelIntfExample = """
 package com.example @target(Scala)
 @codecPackage("generated")

--- a/library/src/test/scala/JsonSchemaExample.scala
+++ b/library/src/test/scala/JsonSchemaExample.scala
@@ -957,7 +957,7 @@ package generated
 
 import _root_.sjsonnew.JsonFormat
 
-trait GreetingsFormats { self: generated.GreetingHeaderFormats with sjsonnew.BasicJsonProtocol with generated.SimpleGreetingFormats with generated.GreetingExtraImplFormats with generated.GreetingWithAttachmentsFormats =>
+trait GreetingsFormats { self: generated.GreetingHeaderFormats with generated.PriorityLevelFormats with sjsonnew.BasicJsonProtocol with generated.SimpleGreetingFormats with generated.GreetingExtraImplFormats with generated.GreetingWithAttachmentsFormats =>
 implicit lazy val GreetingsFormat: JsonFormat[com.example.Greetings] = flatUnionFormat3[com.example.Greetings, com.example.SimpleGreeting, com.example.GreetingExtraImpl, com.example.GreetingWithAttachments]("type")
 }
 /**
@@ -969,7 +969,7 @@ package generated
 
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
 
-trait SimpleGreetingFormats { self: generated.GreetingHeaderFormats with sjsonnew.BasicJsonProtocol =>
+trait SimpleGreetingFormats { self: generated.GreetingHeaderFormats with generated.PriorityLevelFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val SimpleGreetingFormat: JsonFormat[com.example.SimpleGreeting] = new JsonFormat[com.example.SimpleGreeting] {
   override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): com.example.SimpleGreeting = {
     __jsOpt match {
@@ -1000,7 +1000,7 @@ package generated
 
 import _root_.sjsonnew.JsonFormat
 
-trait GreetingExtraFormats { self: generated.GreetingHeaderFormats with sjsonnew.BasicJsonProtocol with generated.GreetingExtraImplFormats =>
+trait GreetingExtraFormats { self: generated.GreetingHeaderFormats with generated.PriorityLevelFormats with sjsonnew.BasicJsonProtocol with generated.GreetingExtraImplFormats =>
 implicit lazy val GreetingExtraFormat: JsonFormat[com.example.GreetingExtra] = flatUnionFormat1[com.example.GreetingExtra, com.example.GreetingExtraImpl]("type")
 }
 /**
@@ -1012,7 +1012,7 @@ package generated
 
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
 
-trait GreetingExtraImplFormats { self: generated.GreetingHeaderFormats with sjsonnew.BasicJsonProtocol =>
+trait GreetingExtraImplFormats { self: generated.GreetingHeaderFormats with generated.PriorityLevelFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val GreetingExtraImplFormat: JsonFormat[com.example.GreetingExtraImpl] = new JsonFormat[com.example.GreetingExtraImpl] {
   override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): com.example.GreetingExtraImpl = {
     __jsOpt match {
@@ -1047,7 +1047,7 @@ package generated
 
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
 
-trait GreetingWithAttachmentsFormats { self: generated.GreetingHeaderFormats with sjsonnew.BasicJsonProtocol =>
+trait GreetingWithAttachmentsFormats { self: generated.GreetingHeaderFormats with generated.PriorityLevelFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val GreetingWithAttachmentsFormat: JsonFormat[com.example.GreetingWithAttachments] = new JsonFormat[com.example.GreetingWithAttachments] {
   override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): com.example.GreetingWithAttachments = {
     __jsOpt match {
@@ -1080,7 +1080,7 @@ package generated
 
 import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
 
-trait GreetingHeaderFormats { self: java.util.DateFormats with generated.PriorityLevelFormats with sjsonnew.BasicJsonProtocol =>
+trait GreetingHeaderFormats { self: generated.PriorityLevelFormats with sjsonnew.BasicJsonProtocol =>
 implicit lazy val GreetingHeaderFormat: JsonFormat[com.example.GreetingHeader] = new JsonFormat[com.example.GreetingHeader] {
   override def read[J](__jsOpt: Option[J], unbuilder: Unbuilder[J]): com.example.GreetingHeader = {
     __jsOpt match {
@@ -1143,8 +1143,7 @@ implicit lazy val PriorityLevelFormat: JsonFormat[com.example.PriorityLevel] = n
 
 // DO NOT EDIT MANUALLY
 package generated
-trait CustomProtocol extends java.util.DateFormats
-  with sjsonnew.BasicJsonProtocol
+trait CustomProtocol extends sjsonnew.BasicJsonProtocol
   with generated.PriorityLevelFormats
   with generated.GreetingHeaderFormats
   with generated.SimpleGreetingFormats


### PR DESCRIPTION
Fixes https://github.com/sbt/contraband/issues/159

Problem
-------
In Scala 3 self type must enumerate the transitive self types,
which in the context of codecs means all the Formats traits for
all the fields in the child trait, not just that of child traits.

```scala
trait XFormats { self: YFormats => }

trait YFormats { self: ZFormats => }

trait ZFormats
```

In Scala 3, the above won't compile complaining

```scala
scala> trait XFormats { self: YFormats => }
     | trait YFormats { self: ZFormats => }
     | trait ZFormats
     |
-- Error:
1 |trait XFormats { self: YFormats => }
  |      ^
  |missing requirement: self type YFormats & XFormats of trait XFormats does not conform to self type ZFormats
  |of required trait YFormats
```

Solution
--------
This genenrally improves the lookup of format type,
first by traversing lazy type, list type, and non-null type,
and looking up the named types in the local schema.
Then recursively all fields' format types are returned to generate
the list of self types.

In general though, since the protocol object that extends all traits
have been working fine in Scala 2, this mostly amounts to
type beurocracy to satisfy Scala 3 (lampepfl/dotty 2214).