### PR TITLE
Fixes stackoverflow

### DIFF
--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -278,8 +278,15 @@ class CodecCodeGen(
   private def getRequiredFormats(s: Document, d: TypeDefinition): List[String] = {
     val typeFormats =
       d match {
-        case _: EnumTypeDefinition   => Nil
-        case c: RecordLikeDefinition => c.fields flatMap { f => lookupFormats(s, f.fieldType) }
+        case _: EnumTypeDefinition => Nil
+        case c: RecordLikeDefinition =>
+          c.fields flatMap { f =>
+            // if the field type is d, we don't need additional codec
+            lookupDefinition(s, f.fieldType.name) match {
+              case Some((s1, d1)) if s1 == s && d1 == d => Nil
+              case _                                    => lookupFormats(s, f.fieldType)
+            }
+          }
       }
     typeFormats ++ codecParents
   }

--- a/plugin/src/sbt-test/sbt-contraband/recursive-type/build.sbt
+++ b/plugin/src/sbt-test/sbt-contraband/recursive-type/build.sbt
@@ -1,0 +1,8 @@
+import sbt.contraband._
+
+lazy val root = (project in file("."))
+  .enablePlugins(ContrabandPlugin, JsonCodecPlugin)
+  .settings(
+    name := "example",
+    libraryDependencies += "com.eed3si9n" %% "sjson-new-scalajson" % contrabandSjsonNewVersion.value,
+  )

--- a/plugin/src/sbt-test/sbt-contraband/recursive-type/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-contraband/recursive-type/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scala-sbt" % "sbt-contraband" % pluginVersion)
+}

--- a/plugin/src/sbt-test/sbt-contraband/recursive-type/src/main/contraband/treeView.contra
+++ b/plugin/src/sbt-test/sbt-contraband/recursive-type/src/main/contraband/treeView.contra
@@ -1,0 +1,9 @@
+package sbt.internal.graph
+@target(Scala)
+@codecPackage("sbt.internal.graph.codec")
+@fullCodec("JsonProtocol")
+
+type ModuleModel {
+  text: String!
+  children: [sbt.internal.graph.ModuleModel]
+}

--- a/plugin/src/sbt-test/sbt-contraband/recursive-type/test
+++ b/plugin/src/sbt-test/sbt-contraband/recursive-type/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
Problem
-------
Given a recurisve type that includes itself as a field,
Contraband currently stackoverflows, trying to keep looking for the
format type.

Solution
--------
Check if the field type is locally defined, and avoid traversing into
it.