### PR TITLE
Make printing of field name more clear

### DIFF
--- a/library/src/main/scala/sbt/contraband/ScalaCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/ScalaCodeGen.scala
@@ -348,7 +348,7 @@ class ScalaCodeGen(
       case None if f.fieldType.isListType || !f.fieldType.isNotNullType =>
         if (intfLang == "Scala") renderScalaValue(NullValue(), f.fieldType)
         else renderJavaValue(NullValue(), f.fieldType)
-      case _ => sys.error(s"Needs a default value for field ${f.name}.")
+      case _ => sys.error(s"Needs a default value for field: ${f.name}.")
     }
 
   private def genApplyOverloads(r: ObjectTypeDefinition, allFields: List[FieldDefinition], intfLang: String): List[String] =


### PR DESCRIPTION
A minor QoL improvement, in my case I have a field literally called `name` in this error case and because of that its printing `java.lang.RuntimeException: Needs a default value for field name.` and it wasn't clear that the fields name is actually `name`.

Putting a colon here should help with this confusion.