### PR TITLE
Simplify scripted tests using globs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,5 +74,11 @@ lazy val plugin = (project in file("plugin"))
         case _      => "2.0.0-M3"
       }
     },
+    scriptedSbt := {
+      scalaBinaryVersion.value match {
+        case "2.12" => "1.10.7"
+        case _      => "2.0.0-M3"
+      }
+    },
     publishLocal := (publishLocal dependsOn (library / publishLocal)).value,
   )

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/build.sbt
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/build.sbt
@@ -11,11 +11,6 @@ lazy val root = (project in file(".")).
       if (substitutions contains name) substitutions(name) :: Nil
       else ((Compile / generateContrabands / contrabandFormatsForType).value)(tpe)
     },
-    TaskKey[Unit]("check") := {
-      val dir = (Compile / generateContrabands / sourceManaged).value
-      val src = dir / "generated" / "CustomProtocol.scala"
-      assert(src.isFile)
-    },
     libraryDependencies += "com.eed3si9n" %% "sjson-new-scalajson" % contrabandSjsonNewVersion.value
     // scalacOptions += "-Xlog-implicits"
   )

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/test
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-java/test
@@ -2,6 +2,6 @@
 
 > compile
 
-> check
+$ exists target/**/src_managed/main/generated/CustomProtocol.scala
 
 > run

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/build.sbt
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/build.sbt
@@ -11,11 +11,6 @@ lazy val root = (project in file(".")).
       if (substitutions contains name) substitutions(name) :: Nil
       else ((Compile / generateContrabands / contrabandFormatsForType).value)(tpe)
     },
-    TaskKey[Unit]("check") := {
-      val dir = (Compile / generateContrabands / sourceManaged).value
-      val src = dir / "generated" / "CustomProtocol.scala"
-      assert(src.isFile)
-    },
     libraryDependencies += "com.eed3si9n" %% "sjson-new-scalajson" % contrabandSjsonNewVersion.value
     // scalacOptions += "-Xlog-implicits"
   )

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/test
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-mixed/test
@@ -2,6 +2,6 @@
 
 > compile
 
-> check
+$ exists target/**/src_managed/main/generated/CustomProtocol.scala
 
 > run

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/build.sbt
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/build.sbt
@@ -5,11 +5,6 @@ lazy val root = (project in file(".")).
   settings(
     name := "example",
     scalaVersion := "2.13.15",
-    TaskKey[Unit]("check") := {
-      val dir = (Compile / generateContrabands / sourceManaged).value
-      val src = dir / "com" / "example" / "codec" / "CustomJsonProtocol.scala"
-      assert(src.isFile)
-    },
     libraryDependencies += "com.eed3si9n" %% "sjson-new-scalajson" % contrabandSjsonNewVersion.value
     // scalacOptions += "-Xlog-implicits"
   )

--- a/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/test
+++ b/plugin/src/sbt-test/sbt-contraband/roundtrip-test-scala/test
@@ -2,6 +2,6 @@
 
 > compile
 
-> check
+$ exists target/**/src_managed/main/com/example/codec/CustomJsonProtocol.scala
 
 > run

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.3
+sbt.version=1.10.7


### PR DESCRIPTION
After support for globs in scripted tests:
* https://github.com/sbt/sbt/pull/7933
* https://github.com/sbt/sbt/pull/7932

The changes introduced in #184 can be simplified.