### PR TITLE
fix old varargs syntax warnings

### DIFF
--- a/library/src/main/scala/sbt/contraband/CodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodeGen.scala
@@ -31,9 +31,9 @@ abstract class CodeGenerator {
       }
 
     def mapV(f: String => String): ListMap[T, String] =
-      ListMap(m.toList map { case (k, v) =>
+      ListMap(m.toList.map { case (k, v) =>
         (k, f(v))
-      }: _*)
+      }*)
   }
 
   implicit protected class IndentationAwareString(code: String) {

--- a/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/CodecCodeGen.scala
@@ -249,7 +249,7 @@ class CodecCodeGen(
         case _ => d :: Nil
       }
     val allDefinitions = ds flatMap getAllDefinitions
-    val dependencies: Map[String, List[String]] = Map(allDefinitions map { d =>
+    val dependencies: Map[String, List[String]] = Map(allDefinitions.map { d =>
       val requiredFormats =
         if (ds.contains(d)) getRequiredFormats(s, d)
         else getAllRequiredFormats(s, d :: Nil)
@@ -258,7 +258,7 @@ class CodecCodeGen(
           lookupChildLeaves(s, i).map(c => fullFormatsName(s, c)) ::: requiredFormats
         case _ => requiredFormats
       })
-    }: _*)
+    }*)
     val xs = Dag.topologicalSortUnchecked[String](seedFormats) { s => dependencies.get(s).getOrElse(Nil) }
     xs.reverse
   }

--- a/library/src/main/scala/sbt/contraband/JavaCodeGen.scala
+++ b/library/src/main/scala/sbt/contraband/JavaCodeGen.scala
@@ -25,9 +25,13 @@ class JavaCodeGen(
   }
 
   override def generate(s: Document): ListMap[File, String] =
-    ListMap((s.definitions collect { case td: TypeDefinition =>
-      td
-    }) flatMap (generate(s, _).toList): _*) mapV (_.indented)
+    ListMap(
+      s.definitions
+        .collect { case td: TypeDefinition =>
+          td
+        }
+        .flatMap(generate(s, _).toList)*
+    ) mapV (_.indented)
 
   override def generateInterface(s: Document, i: InterfaceTypeDefinition): ListMap[File, String] = {
     val InterfaceTypeDefinition(name, namespace, interfaces, fields, dirs, comments, trailingComments, position) = i


### PR DESCRIPTION
```
[warn] -- Warning: /home/runner/work/contraband/contraband/library/src/main/scala/sbt/contraband/CodeGen.scala:36:9 
[warn] 36 |      }: _*)
[warn]    |         ^
[warn]    |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]    |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/contraband/contraband/library/src/main/scala/sbt/contraband/CodecCodeGen.scala:261:7 
[warn] 261 |    }: _*)
[warn]     |       ^
[warn]     |The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
```